### PR TITLE
Improve generator workflow and defaults

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -32,6 +32,10 @@ pub struct ParserApp {
     pub terminals: Vec<char>,
     pub current_page: usize,
     pub generate_result: String,
+    pub generator_ast_preview: String,
+    pub generator_source_preview: String,
+    pub generator_expression_preview: String,
+    pub generator_notes: Vec<String>,
     pub terminal_types: HashMap<char, String>,
     pub run_result: String,
     pub generator_engine: GeneratorEngine,
@@ -47,6 +51,10 @@ impl Default for ParserApp {
             terminals: vec![],
             current_page: 0,
             generate_result: String::new(),
+            generator_ast_preview: String::new(),
+            generator_source_preview: String::new(),
+            generator_expression_preview: String::new(),
+            generator_notes: Vec::new(),
             terminal_types: HashMap::new(),
             run_result: String::new(),
             generator_engine: GeneratorEngine::new(),
@@ -130,6 +138,7 @@ impl ParserApp {
                 self.terminals = parse_grammar_text(&self.reducer_string)
                     .map(|grammar| terminals_from_grammar(&grammar))
                     .unwrap_or_default();
+                self.apply_default_terminal_types();
             }
         });
     }
@@ -137,13 +146,54 @@ impl ParserApp {
     pub fn generate_code(&mut self) {
         self.generator_engine
             .set_terminal_types(self.terminal_types.clone());
-        self.generate_result = self
+        match self
             .generator_engine
-            .generate_code(&self.reducer_string, &self.input_string);
+            .generate_output(&self.reducer_string, &self.input_string)
+        {
+            Ok(output) => {
+                self.generator_ast_preview = output.ast_preview;
+                self.generator_source_preview = output.source_preview;
+                self.generator_expression_preview =
+                    output.evaluation_expression.unwrap_or_else(|| "<not available>".to_string());
+                self.generator_notes = output.notes;
+                self.generate_result = output.generated_code;
+                self.run_result.clear();
+            }
+            Err(err) => {
+                self.generator_ast_preview.clear();
+                self.generator_source_preview.clear();
+                self.generator_expression_preview.clear();
+                self.generator_notes = vec![err.clone()];
+                self.generate_result = err;
+                self.run_result.clear();
+            }
+        }
     }
 
     pub fn run_rust_code(&mut self) {
         self.run_result = self.generator_engine.run_rust_code(&self.generate_result);
+    }
+
+    pub fn apply_default_terminal_types(&mut self) {
+        for &terminal in &self.terminals {
+            self.terminal_types
+                .entry(terminal)
+                .or_insert_with(|| default_terminal_role(terminal).to_string());
+        }
+    }
+}
+
+pub fn default_terminal_role(symbol: char) -> &'static str {
+    match symbol {
+        '+' => "Add",
+        '-' => "Sub",
+        '*' => "Mul",
+        '/' => "Div",
+        '%' => "Mod",
+        '(' | '<' | '[' | '{' => "LParen",
+        ')' | '>' | ']' | '}' => "RParen",
+        '0'..='9' => "Num",
+        _ => "Token",
     }
 }
 

--- a/src/generator_engine.rs
+++ b/src/generator_engine.rs
@@ -3,6 +3,18 @@ use lr0_parser_rs::grammar::{parse_grammar_text, parse_input_text};
 use lr0_parser_rs::lr::compile;
 use lr0_parser_rs::runtime::run;
 use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenerationOutput {
+    pub ast_preview: String,
+    pub source_preview: String,
+    pub evaluation_expression: Option<String>,
+    pub generated_code: String,
+    pub notes: Vec<String>,
+}
 
 pub struct GeneratorEngine {
     pub terminal_types: HashMap<char, String>,
@@ -19,106 +31,251 @@ impl GeneratorEngine {
         self.terminal_types = terminal_types;
     }
 
-    pub fn generate_code(&self, reducer_string: &str, input_string: &str) -> String {
-        let grammar = match parse_grammar_text(reducer_string) {
-            Ok(grammar) => grammar,
-            Err(err) => return format!("Failed to parse grammar: {err:?}"),
-        };
+    pub fn generate_output(
+        &self,
+        reducer_string: &str,
+        input_string: &str,
+    ) -> Result<GenerationOutput, String> {
+        let grammar = parse_grammar_text(reducer_string)
+            .map_err(|err| format!("Failed to parse grammar: {err:?}"))?;
+        let machine =
+            compile(&grammar).map_err(|err| format!("Failed to compile parser: {err:?}"))?;
+        let input = parse_input_text(input_string)
+            .map_err(|err| format!("Failed to parse input: {err:?}"))?;
+        let result =
+            run(&machine, &input).map_err(|err| format!("Failed to run parser: {err:?}"))?;
 
-        let machine = match compile(&grammar) {
-            Ok(machine) => machine,
-            Err(err) => return format!("Failed to compile parser: {err:?}"),
-        };
+        let ast_preview = result.ast.to_string();
+        let source_preview = self.render_source_preview(&result.ast);
+        let evaluation_expression = self.render_evaluation_expression(&result.ast);
 
-        let input = match parse_input_text(input_string) {
-            Ok(input) => input,
-            Err(err) => return format!("Failed to parse input: {err:?}"),
-        };
+        let mut notes = Vec::new();
+        if source_preview.is_empty() {
+            notes.push("The reconstructed source preview is empty.".to_string());
+        }
+        if evaluation_expression.is_none() {
+            notes.push(
+                "Assign arithmetic roles such as Num/Add/Mul/LParen/RParen to generate an evaluable Rust expression."
+                    .to_string(),
+            );
+        }
+        if self.terminal_types.is_empty() {
+            notes.push(
+                "No terminal role overrides are set yet, so raw terminal characters are used."
+                    .to_string(),
+            );
+        }
 
-        let result = match run(&machine, &input) {
-            Ok(result) => result,
-            Err(err) => return format!("Failed to run parser: {err:?}"),
-        };
+        let generated_code = self.build_rust_program(
+            &ast_preview,
+            &source_preview,
+            evaluation_expression.as_deref(),
+        );
 
-        let mut generated_code = String::new();
-        generated_code.push_str("// Generated Rust code from AST\n");
-        generated_code.push_str("fn main() {\n");
-
-        let expression = self.generate_expression_from_ast(&result.ast);
-        generated_code.push_str(&format!(
-            "    let result_1 = {}; // Evaluated expression\n",
-            expression
-        ));
-        generated_code.push_str("    println!(\"Result: {}\", result_1);\n");
-        generated_code.push_str("}\n");
-        generated_code
+        Ok(GenerationOutput {
+            ast_preview,
+            source_preview,
+            evaluation_expression,
+            generated_code,
+            notes,
+        })
     }
 
-    fn generate_expression_from_ast(&self, node: &AstNode) -> String {
-        match node {
-            AstNode::NonTerminal(symbol, children) => match *symbol {
-                'E' | 'B' => {
-                    if children.len() == 1 {
-                        self.generate_expression_from_ast(&children[0])
-                    } else if children.len() == 3 {
-                        let left = self.generate_expression_from_ast(&children[0]);
-                        let operator = self.get_operator_from_ast(&children[1]);
-                        let right = self.generate_expression_from_ast(&children[2]);
-                        format!("({} {} {})", left, operator, right)
-                    } else {
-                        format!("unknown_structure_{}", symbol)
-                    }
-                }
-                _ => {
-                    if children.len() == 1 {
-                        self.generate_expression_from_ast(&children[0])
-                    } else {
-                        format!("unknown_nonterminal_{}", symbol)
-                    }
-                }
-            },
-            AstNode::Terminal(symbol) => {
-                let default_type = "Token".to_string();
-                let token_type = self.terminal_types.get(symbol).unwrap_or(&default_type);
+    fn render_source_preview(&self, node: &AstNode) -> String {
+        let mut output = String::new();
+        self.push_rendered_terminals(node, &mut output, false);
+        output
+    }
 
-                match token_type.as_str() {
-                    "Num" => symbol.to_string(),
-                    _ => format!("token_{}", symbol),
-                }
+    fn render_evaluation_expression(&self, node: &AstNode) -> Option<String> {
+        let mut output = String::new();
+        self.push_rendered_terminals(node, &mut output, true)
+            .then_some(output)
+    }
+
+    fn push_rendered_terminals(
+        &self,
+        node: &AstNode,
+        output: &mut String,
+        arithmetic_only: bool,
+    ) -> bool {
+        match node {
+            AstNode::Terminal(symbol) => {
+                let rendered = if arithmetic_only {
+                    self.render_terminal_for_evaluation(*symbol)
+                } else {
+                    Some(self.render_terminal_for_source(*symbol))
+                };
+
+                let Some(rendered) = rendered else {
+                    return false;
+                };
+                output.push_str(&rendered);
+                true
             }
+            AstNode::NonTerminal(_, children) => children
+                .iter()
+                .all(|child| self.push_rendered_terminals(child, output, arithmetic_only)),
         }
     }
 
-    fn get_operator_from_ast(&self, node: &AstNode) -> String {
-        match node {
-            AstNode::Terminal(symbol) => {
-                let default_type = "Token".to_string();
-                let token_type = self.terminal_types.get(symbol).unwrap_or(&default_type);
-
-                match token_type.as_str() {
-                    "Add" => "+".to_string(),
-                    "Mul" => "*".to_string(),
-                    "L_paren" => "(".to_string(),
-                    "R_paren" => ")".to_string(),
-                    "Token" => String::new(),
-                    _ => symbol.to_string(),
-                }
-            }
-            _ => String::new(),
+    fn render_terminal_for_source(&self, symbol: char) -> String {
+        match self.terminal_role(symbol).as_str() {
+            "Ignore" => String::new(),
+            "LParen" | "L_paren" => "(".to_string(),
+            "RParen" | "R_paren" => ")".to_string(),
+            _ => symbol.to_string(),
         }
+    }
+
+    fn render_terminal_for_evaluation(&self, symbol: char) -> Option<String> {
+        let rendered = match self.terminal_role(symbol).as_str() {
+            "Num" => symbol.to_string(),
+            "Add" => "+".to_string(),
+            "Sub" => "-".to_string(),
+            "Mul" => "*".to_string(),
+            "Div" => "/".to_string(),
+            "Mod" => "%".to_string(),
+            "LParen" | "L_paren" => "(".to_string(),
+            "RParen" | "R_paren" => ")".to_string(),
+            "Ignore" => String::new(),
+            _ => return None,
+        };
+        Some(rendered)
+    }
+
+    fn terminal_role(&self, symbol: char) -> String {
+        self.terminal_types
+            .get(&symbol)
+            .cloned()
+            .unwrap_or_else(|| "Token".to_string())
+    }
+
+    fn build_rust_program(
+        &self,
+        ast_preview: &str,
+        source_preview: &str,
+        evaluation_expression: Option<&str>,
+    ) -> String {
+        let escaped_ast = escape_rust_string(ast_preview);
+        let escaped_source = escape_rust_string(source_preview);
+
+        let mut generated = String::new();
+        generated.push_str("// Generated by the LR(0) Parser GUI\n");
+        generated.push_str("fn generated_ast() -> &'static str {\n");
+        generated.push_str(&format!("    \"{}\"\n", escaped_ast));
+        generated.push_str("}\n\n");
+        generated.push_str("fn generated_source() -> &'static str {\n");
+        generated.push_str(&format!("    \"{}\"\n", escaped_source));
+        generated.push_str("}\n\n");
+        generated.push_str("fn main() {\n");
+        generated.push_str("    println!(\"AST:\\n{}\", generated_ast());\n");
+        generated.push_str("    println!(\"Source preview: {}\", generated_source());\n");
+
+        if let Some(expression) = evaluation_expression {
+            generated.push_str(&format!("    let value = {};\n", expression));
+            generated.push_str("    println!(\"Evaluated value: {}\", value);\n");
+        } else {
+            generated.push_str(
+                "    println!(\"Evaluated value: <not available for current terminal mappings>\");\n",
+            );
+        }
+
+        generated.push_str("}\n");
+        generated
     }
 
     pub fn run_rust_code(&self, generated_code: &str) -> String {
-        if generated_code.is_empty() {
+        if generated_code.trim().is_empty() {
             return "No code to run. Please generate code first.".to_string();
         }
 
-        "Not implemented".to_string()
+        let build_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("generated");
+
+        if let Err(err) = fs::create_dir_all(&build_dir) {
+            return format!("Failed to create build directory: {err}");
+        }
+
+        let source_path = build_dir.join("generated_main.rs");
+        let binary_path = build_dir.join(format!("generated_program{}", std::env::consts::EXE_SUFFIX));
+
+        if let Err(err) = fs::write(&source_path, generated_code) {
+            return format!("Failed to write generated source: {err}");
+        }
+
+        let compile_output = match Command::new("rustc")
+            .arg("--edition=2024")
+            .arg(&source_path)
+            .arg("-o")
+            .arg(&binary_path)
+            .output()
+        {
+            Ok(output) => output,
+            Err(err) => return format!("Failed to invoke rustc: {err}"),
+        };
+
+        if !compile_output.status.success() {
+            return format!(
+                "Rust compilation failed.\n{}",
+                String::from_utf8_lossy(&compile_output.stderr)
+            );
+        }
+
+        let run_output = match Command::new(&binary_path).output() {
+            Ok(output) => output,
+            Err(err) => return format!("Failed to run generated binary: {err}"),
+        };
+
+        let stdout = String::from_utf8_lossy(&run_output.stdout);
+        let stderr = String::from_utf8_lossy(&run_output.stderr);
+
+        if run_output.status.success() {
+            if stderr.trim().is_empty() {
+                stdout.trim_end().to_string()
+            } else {
+                format!("{}\n\nstderr:\n{}", stdout.trim_end(), stderr.trim_end())
+            }
+        } else if stdout.trim().is_empty() {
+            format!("Generated binary failed.\n{}", stderr.trim_end())
+        } else {
+            format!(
+                "Generated binary failed.\nstdout:\n{}\n\nstderr:\n{}",
+                stdout.trim_end(),
+                stderr.trim_end()
+            )
+        }
     }
+}
+
+fn escape_rust_string(value: &str) -> String {
+    value.chars().flat_map(char::escape_default).collect()
 }
 
 impl Default for GeneratorEngine {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_output_builds_source_preview() {
+        let mut engine = GeneratorEngine::new();
+        engine.terminal_types.insert('+', "Add".to_string());
+        engine.terminal_types.insert('*', "Mul".to_string());
+        engine.terminal_types.insert('1', "Num".to_string());
+        engine.terminal_types.insert('0', "Num".to_string());
+
+        let output = engine
+            .generate_output("E -> E*B\nE -> E+B\nE -> B\nB -> 0\nB -> 1", "1+0")
+            .unwrap();
+
+        assert!(output.source_preview.contains("1+0"));
+        assert_eq!(output.evaluation_expression.as_deref(), Some("1+0"));
     }
 }

--- a/src/pages/generator.rs
+++ b/src/pages/generator.rs
@@ -2,154 +2,189 @@ use crate::app::ParserApp;
 use eframe::egui;
 
 impl ParserApp {
-    // Generatorページの表示（4:6の比率）
     pub fn show_generator_page(&mut self, ui: &mut egui::Ui) {
-        // 左右のレイアウト（4:6の比率）
         ui.horizontal(|ui| {
-            // 左側パネル（40%）- 終端記号リスト
             ui.allocate_ui_with_layout(
-                egui::Vec2::new(ui.available_width() * 0.4, ui.available_height()),
+                egui::Vec2::new(ui.available_width() * 0.36, ui.available_height()),
                 egui::Layout::top_down(egui::Align::LEFT),
                 |ui| {
-                    ui.add_space(15.0); // セクション間の余白
-                    ui.label(egui::RichText::new("Terminal Symbols:").size(18.0));
+                    ui.add_space(12.0);
+                    ui.label(egui::RichText::new("Terminal Roles").size(18.0).strong());
+                    ui.label(
+                        egui::RichText::new(
+                            "Map terminals to arithmetic roles to unlock expression generation.",
+                        )
+                        .size(12.0)
+                        .color(egui::Color32::GRAY),
+                    );
                     ui.add_space(10.0);
 
-                    // 終端記号リスト表示エリア
-                    egui::ScrollArea::vertical().id_salt("terminal_symbols_area")
-                        .min_scrolled_height(400.0)
+                    egui::ScrollArea::vertical()
+                        .id_salt("terminal_symbols_area")
+                        .max_height(300.0)
                         .show(ui, |ui| {
                             if self.terminals.is_empty() {
                                 ui.add(
                                     egui::Label::new(
-                                        egui::RichText::new("No terminal symbols found.\nPlease check the Parser page first.")
-                                            .size(14.0)
-                                            .color(egui::Color32::GRAY),
+                                        egui::RichText::new(
+                                            "No terminals available yet.\nParse a grammar on the Parser page first.",
+                                        )
+                                        .size(14.0)
+                                        .color(egui::Color32::GRAY),
                                     )
                                     .wrap(),
                                 );
                             } else {
-                                // 終端記号をクローンしてループ処理
-                                let terminals_clone = self.terminals.clone();
-                                for (i, &symbol) in terminals_clone.iter().enumerate() {
+                                let terminals = self.terminals.clone();
+                                for (index, symbol) in terminals.iter().enumerate() {
                                     ui.horizontal(|ui| {
-                                        // 番号とシンボル表示
                                         ui.label(
-                                            egui::RichText::new(format!("{}.", i + 1))
-                                                .size(16.0)
-                                                .monospace(),
+                                            egui::RichText::new(format!("{:>2}.", index + 1))
+                                                .monospace()
+                                                .size(14.0),
                                         );
                                         ui.label(
-                                            egui::RichText::new(format!("{}", symbol))
-                                                .size(16.0)
+                                            egui::RichText::new(symbol.to_string())
                                                 .monospace()
+                                                .size(16.0)
                                                 .strong(),
                                         );
-
-                                        ui.add_space(10.0); // シンボルとプルダウンの間隔
-
-                                        // プルダウンメニュー
-                                        self.show_terminal_dropdown(ui, symbol);
+                                        ui.add_space(10.0);
+                                        self.show_terminal_dropdown(ui, *symbol);
                                     });
-                                    ui.add_space(8.0); // 各行の間隔
+                                    ui.add_space(6.0);
                                 }
                             }
                         });
 
-                    ui.add_space(20.0); // セクション間の余白
-
-                    // Target String入力セクション
-                    ui.label(egui::RichText::new("Target String:").size(18.0));
-                    ui.add_space(10.0);
+                    ui.add_space(16.0);
+                    ui.label(egui::RichText::new("Target String").size(18.0).strong());
+                    ui.add_space(8.0);
                     ui.text_edit_singleline(&mut self.input_string);
 
-                    ui.add_space(20.0); // セクション間の余白
-
-                    // Generateボタン
-                    if ui.button(egui::RichText::new("Generate Code").size(18.0)).clicked() {
+                    ui.add_space(16.0);
+                    if ui
+                        .button(egui::RichText::new("Generate Code").size(17.0))
+                        .clicked()
+                    {
                         self.generate_code();
                     }
 
-                    ui.add_space(10.0); // ボタン間の余白
-
-                    // Run Rust Codeボタン
-                    if ui.button(egui::RichText::new("Run Rust Code").size(18.0)).clicked() {
+                    ui.add_space(8.0);
+                    if ui
+                        .button(egui::RichText::new("Run Generated Rust").size(17.0))
+                        .clicked()
+                    {
                         self.run_rust_code();
                     }
+
+                    ui.add_space(16.0);
+                    ui.label(egui::RichText::new("Notes").size(18.0).strong());
+                    ui.add_space(8.0);
+                    egui::ScrollArea::vertical()
+                        .id_salt("generator_notes_area")
+                        .max_height(160.0)
+                        .show(ui, |ui| {
+                            if self.generator_notes.is_empty() {
+                                ui.label(
+                                    egui::RichText::new(
+                                        "No notes yet. Generate code to see validation hints.",
+                                    )
+                                    .size(13.0)
+                                    .color(egui::Color32::GRAY),
+                                );
+                            } else {
+                                for note in &self.generator_notes {
+                                    ui.label(
+                                        egui::RichText::new(format!("- {}", note))
+                                            .size(13.0)
+                                            .color(egui::Color32::LIGHT_BLUE),
+                                    );
+                                }
+                            }
+                        });
                 },
             );
 
-            ui.add_space(20.0); // 左右のパネル間の余白
+            ui.add_space(18.0);
 
-            // 右側パネル（60%）- 実行結果表示
             ui.allocate_ui_with_layout(
                 egui::Vec2::new(ui.available_width(), ui.available_height()),
                 egui::Layout::top_down(egui::Align::LEFT),
                 |ui| {
-                    ui.add_space(15.0); // セクション間の余白
-                    ui.label(egui::RichText::new("Generate Result:").size(18.0));
+                    ui.add_space(12.0);
+                    ui.label(egui::RichText::new("Generation Summary").size(18.0).strong());
+                    ui.add_space(8.0);
+                    self.show_preview_card(ui, "AST Preview", &self.generator_ast_preview, 120.0);
                     ui.add_space(10.0);
-
-                    // 実行結果表示エリア
-                    egui::ScrollArea::vertical().id_salt("generate_result_area")
-                        .max_height(200.0)
-                        .show(ui, |ui| {
-                            if self.generate_result.is_empty() {
-                                ui.add(
-                                    egui::Label::new(
-                                        egui::RichText::new("No generation results yet.\nClick 'Generate Code' to generate Rust code from AST.")
-                                            .size(14.0)
-                                            .color(egui::Color32::GRAY),
-                                    )
-                                    .wrap(),
-                                );
-                            } else {
-                                ui.add(
-                                    egui::Label::new(
-                                        egui::RichText::new(&self.generate_result)
-                                            .monospace()
-                                            .size(12.0),
-                                    )
-                                    .wrap(),
-                                );
-                            }
-                        });
-
-                    ui.add_space(20.0); // セクション間の余白
-
-                    // 実行結果セクション
-                    ui.label(egui::RichText::new("Execution Result:").size(18.0));
+                    self.show_preview_card(
+                        ui,
+                        "Reconstructed Source",
+                        &self.generator_source_preview,
+                        70.0,
+                    );
                     ui.add_space(10.0);
+                    self.show_preview_card(
+                        ui,
+                        "Evaluation Expression",
+                        &self.generator_expression_preview,
+                        70.0,
+                    );
 
-                    egui::ScrollArea::vertical().id_salt("run_result_area")
-                        .max_height(200.0)
-                        .show(ui, |ui| {
-                            if self.run_result.is_empty() {
-                                ui.add(
-                                    egui::Label::new(
-                                        egui::RichText::new("No execution results yet.\nClick 'Run Rust Code' to execute generated code.")
-                                            .size(14.0)
-                                            .color(egui::Color32::GRAY),
-                                    )
-                                    .wrap(),
-                                );
-                            } else {
-                                ui.add(
-                                    egui::Label::new(
-                                        egui::RichText::new(&self.run_result)
-                                            .monospace()
-                                            .size(12.0),
-                                    )
-                                    .wrap(),
-                                );
-                            }
-                        });
+                    ui.add_space(14.0);
+                    ui.label(egui::RichText::new("Generated Rust Code").size(18.0).strong());
+                    ui.add_space(8.0);
+                    self.show_preview_card(ui, "Code", &self.generate_result, 210.0);
+
+                    ui.add_space(14.0);
+                    ui.label(egui::RichText::new("Execution Result").size(18.0).strong());
+                    ui.add_space(8.0);
+                    self.show_preview_card(ui, "Run", &self.run_result, 160.0);
                 },
             );
         });
     }
 
-    // 終端記号のプルダウンメニューを表示
+    fn show_preview_card(
+        &self,
+        ui: &mut egui::Ui,
+        label: &str,
+        content: &str,
+        max_height: f32,
+    ) {
+        egui::Frame::group(ui.style()).show(ui, |ui| {
+            ui.set_min_width(ui.available_width());
+            ui.label(
+                egui::RichText::new(label)
+                    .size(14.0)
+                    .strong()
+                    .color(egui::Color32::from_rgb(190, 190, 210)),
+            );
+            ui.add_space(6.0);
+            egui::ScrollArea::vertical()
+                .id_salt(format!("{}_scroll", label))
+                .max_height(max_height)
+                .show(ui, |ui| {
+                    if content.trim().is_empty() {
+                        ui.label(
+                            egui::RichText::new("Nothing yet.")
+                                .size(13.0)
+                                .color(egui::Color32::GRAY),
+                        );
+                    } else {
+                        ui.add(
+                            egui::Label::new(
+                                egui::RichText::new(content)
+                                    .monospace()
+                                    .size(12.5),
+                            )
+                            .wrap(),
+                        );
+                    }
+                });
+        });
+    }
+
     fn show_terminal_dropdown(&mut self, ui: &mut egui::Ui, symbol: char) {
         let current_selection = self
             .terminal_types
@@ -160,20 +195,18 @@ impl ParserApp {
         egui::ComboBox::from_id_salt(format!("combo_{}", symbol))
             .selected_text(&current_selection)
             .show_ui(ui, |ui| {
-                let options = ["Add", "Mul", "L_paren", "R_paren", "Num"];
+                let options = [
+                    "Token", "Num", "Add", "Sub", "Mul", "Div", "Mod", "LParen", "RParen",
+                    "Ignore",
+                ];
                 for option in &options {
-                    if ui
-                        .selectable_value(
-                            self.terminal_types
-                                .entry(symbol)
-                                .or_insert("Token".to_string()),
-                            option.to_string(),
-                            *option,
-                        )
-                        .clicked()
-                    {
-                        // 選択が変更された時の処理（必要に応じて）
-                    }
+                    ui.selectable_value(
+                        self.terminal_types
+                            .entry(symbol)
+                            .or_insert_with(|| "Token".to_string()),
+                        option.to_string(),
+                        *option,
+                    );
                 }
             });
     }

--- a/src/pages/parser.rs
+++ b/src/pages/parser.rs
@@ -193,12 +193,7 @@ impl ParserApp {
                 Ok(machine) => {
                     self.parse_table = Some(build_parse_table(&grammar, &machine));
                     self.terminals = terminals_from_grammar(&grammar);
-
-                    for &terminal in &self.terminals {
-                        self.terminal_types
-                            .entry(terminal)
-                            .or_insert_with(|| "Token".to_string());
-                    }
+                    self.apply_default_terminal_types();
 
                     match parse_input_text(&self.input_string).and_then(|symbols| {
                         run(&machine, &symbols)


### PR DESCRIPTION
## Summary
- enrich the Generator tab with previews, notes, and generated-code execution
- add sensible default terminal role mappings for common symbols
- expand the generator engine to produce source/evaluation previews and runnable Rust code

## Testing
- cargo test --quiet