### PR TITLE
feat: Generator AST tree preview and responsive layout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,12 @@ mod pages;
 use app::ParserApp;
 
 fn main() -> eframe::Result {
-    let options = eframe::NativeOptions::default();
+    let options = eframe::NativeOptions {
+        viewport: eframe::egui::ViewportBuilder::default()
+            .with_inner_size([1200.0, 800.0])
+            .with_min_inner_size([800.0, 600.0]),
+        ..Default::default()
+    };
     eframe::run_native(
         "LR(0) Parser GUI",
         options,

--- a/src/pages/generator.rs
+++ b/src/pages/generator.rs
@@ -1,147 +1,185 @@
 use crate::app::ParserApp;
 use eframe::egui;
+use super::tree::{draw_tree, layout_ast, tree_pixel_height, NODE_R};
 
 impl ParserApp {
     pub fn show_generator_page(&mut self, ui: &mut egui::Ui) {
-        ui.horizontal(|ui| {
-            ui.allocate_ui_with_layout(
-                egui::Vec2::new(ui.available_width() * 0.36, ui.available_height()),
-                egui::Layout::top_down(egui::Align::LEFT),
-                |ui| {
-                    ui.add_space(12.0);
-                    ui.label(egui::RichText::new("Terminal Roles").size(18.0).strong());
-                    ui.label(
-                        egui::RichText::new(
-                            "Map terminals to arithmetic roles to unlock expression generation.",
-                        )
-                        .size(12.0)
-                        .color(egui::Color32::GRAY),
-                    );
-                    ui.add_space(10.0);
+        let avail_h = ui.available_height();
+        let left_w = ui.available_width() * 0.36;
 
-                    egui::ScrollArea::vertical()
-                        .id_salt("terminal_symbols_area")
-                        .max_height(300.0)
-                        .show(ui, |ui| {
-                            if self.terminals.is_empty() {
-                                ui.add(
-                                    egui::Label::new(
-                                        egui::RichText::new(
-                                            "No terminals available yet.\nParse a grammar on the Parser page first.",
-                                        )
-                                        .size(14.0)
-                                        .color(egui::Color32::GRAY),
-                                    )
-                                    .wrap(),
-                                );
-                            } else {
-                                let terminals = self.terminals.clone();
-                                for (index, symbol) in terminals.iter().enumerate() {
-                                    ui.horizontal(|ui| {
-                                        ui.label(
-                                            egui::RichText::new(format!("{:>2}.", index + 1))
-                                                .monospace()
-                                                .size(14.0),
-                                        );
-                                        ui.label(
-                                            egui::RichText::new(symbol.to_string())
-                                                .monospace()
-                                                .size(16.0)
-                                                .strong(),
-                                        );
-                                        ui.add_space(10.0);
-                                        self.show_terminal_dropdown(ui, *symbol);
-                                    });
-                                    ui.add_space(6.0);
-                                }
-                            }
-                        });
+        ui.horizontal_top(|ui| {
+            // ── 左列 ──────────────────────────────────────────────
+            ui.vertical(|ui| {
+                ui.set_width(left_w);
+                egui::ScrollArea::vertical()
+                    .id_salt("gen_left_scroll")
+                    .max_height(avail_h)
+                    .show(ui, |ui| {
+                        ui.add_space(12.0);
+                        ui.label(egui::RichText::new("Terminal Roles").size(18.0).strong());
+                        ui.label(
+                            egui::RichText::new(
+                                "Map terminals to arithmetic roles to unlock expression generation.",
+                            )
+                            .size(12.0)
+                            .color(egui::Color32::GRAY),
+                        );
+                        ui.add_space(10.0);
 
-                    ui.add_space(16.0);
-                    ui.label(egui::RichText::new("Target String").size(18.0).strong());
-                    ui.add_space(8.0);
-                    ui.text_edit_singleline(&mut self.input_string);
-
-                    ui.add_space(16.0);
-                    if ui
-                        .button(egui::RichText::new("Generate Code").size(17.0))
-                        .clicked()
-                    {
-                        self.generate_code();
-                    }
-
-                    ui.add_space(8.0);
-                    if ui
-                        .button(egui::RichText::new("Run Generated Rust").size(17.0))
-                        .clicked()
-                    {
-                        self.run_rust_code();
-                    }
-
-                    ui.add_space(16.0);
-                    ui.label(egui::RichText::new("Notes").size(18.0).strong());
-                    ui.add_space(8.0);
-                    egui::ScrollArea::vertical()
-                        .id_salt("generator_notes_area")
-                        .max_height(160.0)
-                        .show(ui, |ui| {
-                            if self.generator_notes.is_empty() {
-                                ui.label(
+                        if self.terminals.is_empty() {
+                            ui.add(
+                                egui::Label::new(
                                     egui::RichText::new(
-                                        "No notes yet. Generate code to see validation hints.",
+                                        "No terminals available yet.\nParse a grammar on the Parser page first.",
                                     )
-                                    .size(13.0)
+                                    .size(14.0)
                                     .color(egui::Color32::GRAY),
-                                );
-                            } else {
-                                for note in &self.generator_notes {
+                                )
+                                .wrap(),
+                            );
+                        } else {
+                            let terminals = self.terminals.clone();
+                            for (index, symbol) in terminals.iter().enumerate() {
+                                ui.horizontal(|ui| {
                                     ui.label(
-                                        egui::RichText::new(format!("- {}", note))
-                                            .size(13.0)
-                                            .color(egui::Color32::LIGHT_BLUE),
+                                        egui::RichText::new(format!("{:>2}.", index + 1))
+                                            .monospace()
+                                            .size(14.0),
                                     );
-                                }
+                                    ui.label(
+                                        egui::RichText::new(symbol.to_string())
+                                            .monospace()
+                                            .size(16.0)
+                                            .strong(),
+                                    );
+                                    ui.add_space(10.0);
+                                    self.show_terminal_dropdown(ui, *symbol);
+                                });
+                                ui.add_space(6.0);
                             }
-                        });
-                },
-            );
+                        }
+
+                        ui.add_space(16.0);
+                        ui.label(egui::RichText::new("Target String").size(18.0).strong());
+                        ui.add_space(8.0);
+                        ui.text_edit_singleline(&mut self.input_string);
+
+                        ui.add_space(16.0);
+                        if ui
+                            .button(egui::RichText::new("Generate Code").size(17.0))
+                            .clicked()
+                        {
+                            self.generate_code();
+                        }
+
+                        ui.add_space(8.0);
+                        if ui
+                            .button(egui::RichText::new("Run Generated Rust").size(17.0))
+                            .clicked()
+                        {
+                            self.run_rust_code();
+                        }
+
+                        ui.add_space(16.0);
+                        ui.label(egui::RichText::new("Notes").size(18.0).strong());
+                        ui.add_space(8.0);
+                        if self.generator_notes.is_empty() {
+                            ui.label(
+                                egui::RichText::new(
+                                    "No notes yet. Generate code to see validation hints.",
+                                )
+                                .size(13.0)
+                                .color(egui::Color32::GRAY),
+                            );
+                        } else {
+                            for note in &self.generator_notes {
+                                ui.label(
+                                    egui::RichText::new(format!("- {}", note))
+                                        .size(13.0)
+                                        .color(egui::Color32::LIGHT_BLUE),
+                                );
+                            }
+                        }
+                    });
+            });
 
             ui.add_space(18.0);
 
-            ui.allocate_ui_with_layout(
-                egui::Vec2::new(ui.available_width(), ui.available_height()),
-                egui::Layout::top_down(egui::Align::LEFT),
-                |ui| {
+            // ── 右列 ──────────────────────────────────────────────
+            egui::ScrollArea::vertical()
+                .id_salt("gen_right_scroll")
+                .max_height(avail_h)
+                .show(ui, |ui| {
                     ui.add_space(12.0);
                     ui.label(egui::RichText::new("Generation Summary").size(18.0).strong());
                     ui.add_space(8.0);
-                    self.show_preview_card(ui, "AST Preview", &self.generator_ast_preview, 120.0);
+
+                    // AST Preview
+                    ui.label(
+                        egui::RichText::new("AST Preview")
+                            .size(14.0)
+                            .strong()
+                            .color(egui::Color32::from_rgb(190, 190, 210)),
+                    );
+                    ui.add_space(6.0);
+                    if let Some(ast) = self.generator_ast.clone() {
+                        let layout = layout_ast(&ast);
+                        let tree_w = layout.subtree_width.max(60.0);
+                        let tree_h = tree_pixel_height(&layout) + NODE_R * 2.0 + 4.0;
+                        egui::Frame::group(ui.style()).show(ui, |ui| {
+                            ui.set_min_width(ui.available_width());
+                            egui::ScrollArea::both()
+                                .id_salt("gen_ast_scroll")
+                                .max_height(150.0)
+                                .show(ui, |ui| {
+                                    let size = egui::Vec2::new(tree_w, tree_h);
+                                    let (rect, _) =
+                                        ui.allocate_exact_size(size, egui::Sense::hover());
+                                    if ui.is_rect_visible(rect) {
+                                        draw_tree(
+                                            ui.painter(),
+                                            rect.min + egui::Vec2::new(0.0, NODE_R),
+                                            &layout,
+                                        );
+                                    }
+                                });
+                        });
+                    } else {
+                        egui::Frame::group(ui.style()).show(ui, |ui| {
+                            ui.set_min_width(ui.available_width());
+                            ui.label(
+                                egui::RichText::new("Nothing yet.")
+                                    .size(13.0)
+                                    .color(egui::Color32::GRAY),
+                            );
+                        });
+                    }
+
                     ui.add_space(10.0);
                     self.show_preview_card(
                         ui,
                         "Reconstructed Source",
-                        &self.generator_source_preview,
-                        70.0,
+                        &self.generator_source_preview.clone(),
+                        60.0,
                     );
                     ui.add_space(10.0);
                     self.show_preview_card(
                         ui,
                         "Evaluation Expression",
-                        &self.generator_expression_preview,
-                        70.0,
+                        &self.generator_expression_preview.clone(),
+                        60.0,
                     );
 
                     ui.add_space(14.0);
                     ui.label(egui::RichText::new("Generated Rust Code").size(18.0).strong());
                     ui.add_space(8.0);
-                    self.show_preview_card(ui, "Code", &self.generate_result, 210.0);
+                    self.show_preview_card(ui, "Code", &self.generate_result.clone(), 200.0);
 
                     ui.add_space(14.0);
                     ui.label(egui::RichText::new("Execution Result").size(18.0).strong());
                     ui.add_space(8.0);
-                    self.show_preview_card(ui, "Run", &self.run_result, 160.0);
-                },
-            );
+                    self.show_preview_card(ui, "Run", &self.run_result.clone(), 150.0);
+                });
         });
     }
 


### PR DESCRIPTION
## 概要

Generator ページに AST ツリーダイアグラムのプレビューを追加し、レイアウトをレスポンシブ化。

## Generator AST ツリープレビュー

- "Generate Code" 実行後に "AST Preview" セクションへ egui Painter によるツリーダイアグラムを表示
- `pages/tree.rs` の共有描画関数を再利用（終端記号: アンバー / 非終端記号: 緑）
- `GenerationOutput::ast` フィールド経由で `AstNode` を受け取り `ParserApp::generator_ast` に保存
- AST が未生成または生成失敗時は "Nothing yet." にフォールバック

## レスポンシブレイアウト全面改修

旧: `allocate_ui_with_layout` による固定サイズボックス（ウィンドウリサイズに非追従）
新: `ScrollArea::vertical` を外側に配置するレスポンシブ構成

- 左列（Terminal Roles, Target String, Notes）: `ui.set_width` + `ScrollArea::vertical` で全コンテンツをスクロール可能に
- 右列（AST, Source, Code, Run）: `ScrollArea::vertical` で全カードを包む
- 各カードの内部は適切な固定 `max_height`（コンテンツ用スクロール）、外側スクロールがオーバーフローを吸収
- `horizontal_top` に変更して左右列が互いの高さに干渉しないよう修正

## ウィンドウ初期サイズ

- 初期サイズ: 1200×800
- 最小サイズ: 800×600

## テスト計画

- [ ] `cargo build` でコンパイル成功
- [ ] Generator タブ → Generate Code → "AST Preview" にツリーが表示される
- [ ] ウィンドウを縦横にリサイズ → 両列のコンテンツが追従する
- [ ] コンテンツが多い場合にスクロールバーが表示される

🤖 Generated with [Claude Code](https://claude.ai/claude-code)