### PR TITLE
refactor: grammar/input 検証を Applicative 的な独立チェーンへ分離

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod generator_engine;
 mod pages;
+mod validation;
 
 use app::ParserApp;
 

--- a/src/pages/parser.rs
+++ b/src/pages/parser.rs
@@ -1,6 +1,6 @@
 use eframe::egui;
-use lr0_parser_rs::grammar::{GrammarError, parse_grammar_text, parse_input_text};
-use lr0_parser_rs::lr::{ParserError, compile};
+use lr0_parser_rs::grammar::{Grammar, GrammarError, Symbol, parse_grammar_text, parse_input_text};
+use lr0_parser_rs::lr::{CompiledParser, ParserError, compile};
 use lr0_parser_rs::runtime::{RuntimeError, run};
 use lr0_parser_rs::StepAction;
 use std::fmt;
@@ -10,6 +10,7 @@ use crate::app::{
     ParseTableAction, ParserApp, ParserKind, build_animation_trace, build_parse_table,
     terminals_from_grammar,
 };
+use crate::validation::Validation;
 
 enum UiError {
     Grammar(GrammarError),
@@ -65,6 +66,59 @@ impl fmt::Display for UiError {
             }
         }
     }
+}
+
+/// grammar 側のエラー（parse or compile）と input 側のエラーを区別するUI層エラー型。
+/// これにより、両チェーンが互いに独立して失敗したとき両方のエラーを蓄積できる。
+#[derive(Debug)]
+enum InputValidationError {
+    Grammar(GrammarError),
+    Compile(ParserError),
+    Input(GrammarError),
+}
+
+impl fmt::Display for InputValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Grammar(e) => write!(f, "Grammar: {}", UiError::Grammar(e.clone())),
+            Self::Compile(e) => write!(f, "Compile: {}", UiError::Compile(e.clone())),
+            Self::Input(GrammarError::InvalidSymbol(c)) => {
+                write!(f, "Input: '{c}' は非終端記号のため入力文字列に使用できません")
+            }
+            Self::Input(e) => write!(f, "Input: {}", UiError::Grammar(e.clone())),
+        }
+    }
+}
+
+/// grammar parse → compile の依存的逐次チェーンが両方成功したときの中間値。
+struct CompiledGrammar {
+    grammar: Grammar,
+    machine: CompiledParser,
+}
+
+/// grammar 側チェーンと input 側チェーンの両方が成功したときのみ生成される実行リクエスト。
+struct RunRequest {
+    grammar:       Grammar,
+    machine:       CompiledParser,
+    input_symbols: Vec<Symbol>,
+}
+
+/// grammar text の parse → compile を依存的な逐次チェーンとして実行する。
+/// parse が失敗すれば compile は行わない。
+fn validated_compile(grammar_text: &str) -> Validation<InputValidationError, CompiledGrammar> {
+    let grammar = match parse_grammar_text(grammar_text) {
+        Ok(g)  => g,
+        Err(e) => return Validation::invalid(InputValidationError::Grammar(e)),
+    };
+    match compile(&grammar) {
+        Ok(machine) => Validation::valid(CompiledGrammar { grammar, machine }),
+        Err(e)      => Validation::invalid(InputValidationError::Compile(e)),
+    }
+}
+
+/// input text の parse は grammar と独立して行える。
+fn validate_input(input_text: &str) -> Validation<InputValidationError, Vec<Symbol>> {
+    Validation::from_result(parse_input_text(input_text).map_err(InputValidationError::Input))
 }
 
 impl ParserApp {
@@ -515,40 +569,36 @@ impl ParserApp {
     }
 
     fn handle_parse_lr0(&mut self) {
-        let grammar = match parse_grammar_text(&self.reducer_string).map_err(UiError::Grammar) {
-            Ok(g) => g,
-            Err(e) => {
-                self.parser_result = e.to_string();
+        // ── フェーズ1: 独立な2チェーンを Applicative 的に合成 ──────────────────
+        // grammar → compile（依存的逐次）と input parse（独立）は互いに影響しない。
+        // map2 で合成し、両方成功した場合のみ RunRequest を生成する。
+        // 一方または両方が失敗した場合はすべてのエラーを蓄積して表示する。
+        let compiled = validated_compile(&self.reducer_string);
+        let input    = validate_input(&self.input_string);
+
+        let request = match compiled.map2(input, |cg, symbols| RunRequest {
+            grammar:       cg.grammar,
+            machine:       cg.machine,
+            input_symbols: symbols,
+        }) {
+            Validation::Valid(req) => req,
+            Validation::Invalid(errors) => {
+                self.parser_result = errors.iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n");
                 self.parse_table = None;
                 self.parse_trace.clear();
                 return;
             }
         };
 
-        let machine = match compile(&grammar).map_err(UiError::Compile) {
-            Ok(m) => m,
-            Err(e) => {
-                self.parser_result = e.to_string();
-                self.parse_table = None;
-                self.parse_trace.clear();
-                return;
-            }
-        };
-
-        self.parse_table = Some(build_parse_table(&grammar, &machine));
-        self.terminals = terminals_from_grammar(&grammar);
+        // ── フェーズ2: run（RunRequest への依存的な逐次処理） ──────────────────
+        self.parse_table = Some(build_parse_table(&request.grammar, &request.machine));
+        self.terminals   = terminals_from_grammar(&request.grammar);
         self.apply_default_terminal_types();
 
-        let symbols = match parse_input_text(&self.input_string).map_err(UiError::Grammar) {
-            Ok(s) => s,
-            Err(e) => {
-                self.parser_result = e.to_string();
-                self.parse_trace.clear();
-                return;
-            }
-        };
-
-        match run(&machine, &symbols).map_err(UiError::Runtime) {
+        match run(&request.machine, &request.input_symbols).map_err(UiError::Runtime) {
             Ok(_) => {
                 self.parser_result.clear();
             }
@@ -559,9 +609,9 @@ impl ParserApp {
             }
         }
 
-        self.parse_trace = build_animation_trace(&machine, &symbols).unwrap_or_default();
-        self.trace_cursor = 0;
-        self.anim_playing = false;
+        self.parse_trace = build_animation_trace(&request.machine, &request.input_symbols).unwrap_or_default();
+        self.trace_cursor      = 0;
+        self.anim_playing      = false;
         self.anim_last_advance = None;
     }
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,0 +1,84 @@
+#[derive(Debug, PartialEq, Eq)]
+pub enum Validation<E, T> {
+    Valid(T),
+    Invalid(Vec<E>),
+}
+
+impl<E, T> Validation<E, T> {
+    pub fn valid(value: T) -> Self {
+        Validation::Valid(value)
+    }
+
+    pub fn invalid(error: E) -> Self {
+        Validation::Invalid(vec![error])
+    }
+
+    pub fn from_result(r: Result<T, E>) -> Self {
+        match r {
+            Ok(v)  => Validation::Valid(v),
+            Err(e) => Validation::Invalid(vec![e]),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> Validation<E, U> {
+        match self {
+            Validation::Valid(v)       => Validation::Valid(f(v)),
+            Validation::Invalid(errs)  => Validation::Invalid(errs),
+        }
+    }
+
+    /// 互いに独立な2つの検証結果を合成する。
+    /// 両方成功 → f(t, u) を Valid で返す。
+    /// 片方以上が失敗 → 両側のエラーをすべて収集して Invalid で返す。
+    pub fn map2<U, V, F>(self, other: Validation<E, U>, f: F) -> Validation<E, V>
+    where
+        F: FnOnce(T, U) -> V,
+    {
+        match (self, other) {
+            (Validation::Valid(t), Validation::Valid(u)) => Validation::Valid(f(t, u)),
+            (Validation::Invalid(e), Validation::Valid(_)) => Validation::Invalid(e),
+            (Validation::Valid(_), Validation::Invalid(e)) => Validation::Invalid(e),
+            (Validation::Invalid(mut e1), Validation::Invalid(mut e2)) => {
+                e1.append(&mut e2);
+                Validation::Invalid(e1)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map2_both_valid_returns_combined() {
+        let a: Validation<&str, i32> = Validation::valid(1);
+        let b: Validation<&str, i32> = Validation::valid(2);
+        assert_eq!(a.map2(b, |x, y| x + y), Validation::Valid(3));
+    }
+
+    #[test]
+    fn map2_left_invalid_returns_left_errors() {
+        let a: Validation<&str, i32> = Validation::invalid("err_a");
+        let b: Validation<&str, i32> = Validation::valid(2);
+        assert_eq!(a.map2(b, |x, y| x + y), Validation::Invalid(vec!["err_a"]));
+    }
+
+    #[test]
+    fn map2_right_invalid_returns_right_errors() {
+        let a: Validation<&str, i32> = Validation::valid(1);
+        let b: Validation<&str, i32> = Validation::invalid("err_b");
+        assert_eq!(a.map2(b, |x, y| x + y), Validation::Invalid(vec!["err_b"]));
+    }
+
+    #[test]
+    fn map2_both_invalid_accumulates_all_errors_in_order() {
+        let a: Validation<&str, i32> = Validation::invalid("err_a");
+        let b: Validation<&str, i32> = Validation::invalid("err_b");
+        assert_eq!(
+            a.map2(b, |x, y| x + y),
+            Validation::Invalid(vec!["err_a", "err_b"])
+        );
+    }
+}


### PR DESCRIPTION
## 概要

`handle_parse_lr0` の検証フェーズを、依存関係に忠実な構造へリファクタリングしました。

### 変更前の問題

`parse_grammar_text → compile → parse_input_text → run` を逐次実行していたため、grammar が不正だと input の検証が一切行われませんでした。

### 変更後の構造

実際の依存関係を計算構造に反映しました：

- **grammar 側チェーン**（依存的逐次）: `parse_grammar_text → compile` を `validated_compile` にまとめ、`Validation<InputValidationError, CompiledGrammar>` を返す
- **input 側チェーン**（独立）: `parse_input_text` を `validate_input` として独立させ、`Validation<InputValidationError, Vec<Symbol>>` を返す
- **Applicative 合成**: `Validation::map2` で両チェーンを合成し、`RunRequest` を生成してから `run` へ進む

これにより「grammar は compile 失敗、かつ input も不正」のようなケースで両エラーが蓄積されて表示されます。

## 追加ファイル・変更ファイル

| ファイル | 変更種別 |
|---|---|
| `src/validation.rs` | 新規 — `Validation<E, T>` 型（`valid`, `invalid`, `from_result`, `map`, `map2`）と単体テスト4件 |
| `src/main.rs` | `mod validation;` を追加 |
| `src/pages/parser.rs` | `InputValidationError` / `CompiledGrammar` / `RunRequest` / `validated_compile` / `validate_input` / `handle_parse_lr0` 書き換え |

## テスト

- `cargo test` 全11件 pass
- `validation::tests` 4件: `map2` の全パターン（Valid×Valid, Invalid×Valid, Valid×Invalid, Invalid×Invalid）を網羅

🤖 Generated with [Claude Code](https://claude.com/claude-code)