### PR TITLE
refactor: egui architecture overhaul (Page enum / ParseArtifacts / State split / ViewModel)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```sh
+# Build
+cargo build
+
+# Run GUI application
+cargo run
+
+# Run all tests
+cargo test
+
+# Run a single test by name
+cargo test <test_name>
+
+# Run tests in a specific module
+cargo test grammar::tests
+cargo test runtime::tests
+```
+
+## Architecture
+
+This project is a dual-crate workspace in a single `Cargo.toml`:
+
+- **Library** (`lr0_parser_rs`, `src/lib.rs`): pure parsing logic — no GUI, no I/O
+- **Binary** (`lr0-parser-gui`, `src/main.rs`): egui GUI that wraps the library
+
+### Library pipeline
+
+```
+grammar::parse_grammar_text(text)  →  Grammar
+lr::compile(&grammar)              →  CompiledParser
+runtime::run(&machine, &symbols)   →  ParserResult { ast: AstNode }
+runtime::build_trace(...)          →  Vec<ParseStep>   (step-by-step for animation)
+```
+
+Each stage is in its own module:
+
+| Module | Responsibility |
+|---|---|
+| `grammar.rs` | Text → `Grammar` (productions, terminals, non-terminals). Non-terminals must be a single uppercase ASCII char; `$` is the implicit EOF terminal. |
+| `lr.rs` | `Grammar` → `CompiledParser` (LR(0) item sets, action/goto tables). `compile()` returns `Err(ParserError::ConflictReducer)` on Shift/Reduce or Reduce/Reduce conflicts — conflicts are hard errors, never silently resolved. |
+| `runtime.rs` | `CompiledParser` + input → `ParserResult`. Also exports `build_trace` which returns `Vec<ParseStep>` capturing the full step history for the animation UI. |
+| `ast.rs` | `AstNode` enum: `Terminal(char)` or `NonTerminal(char, Vec<AstNode>)`. |
+
+### GUI binary structure
+
+```
+main.rs                  — window setup (1200×800 initial, 800×600 min)
+app.rs                   — ParserApp state struct + eframe App impl
+  ParserApp              — all UI state (parse trace, animation cursor, generator AST, …)
+  ParserKind enum        — Lr0 | Slr | Lalr | Lr1 (only Lr0 is implemented)
+  build_parse_table()    — converts CompiledParser → 2D ParseTableAction grid for display
+  build_animation_trace()— thin wrapper around runtime::build_trace
+pages/
+  parser.rs              — Parser tab UI: input panel, animation trace panel,
+                           AST formation section, parse table section
+  generator.rs           — Generator tab UI: terminal role selectors,
+                           code preview cards (AST tree, source, eval, code, run)
+  tree.rs                — Shared egui Painter tree renderer used by both pages
+                           (LayoutNode, layout_ast, draw_tree, tree_pixel_height)
+generator_engine.rs      — GeneratorEngine: AST → Rust source code generation.
+                           run_generated_code() writes a temp file and shells out to rustc.
+```
+
+### Key design rules
+
+- **LR conflicts are errors**: `lr::compile` returns `Err` on any conflict. The UI surfaces this as a human-readable message via `UiError::Compile`.
+- **Functional core / imperative shell**: library modules (`grammar`, `lr`, `runtime`) are pure functions. Side effects (file I/O, process spawning) are confined to `generator_engine::run_generated_code`.
+- **Algorithm stubs**: `ParserKind::Slr / Lalr / Lr1` exist in `app.rs` as extension points. Selecting them shows "not yet implemented" via `UiError::NotImplemented`. Actual implementations are left for future work.
+- **Shared tree renderer**: `pages/tree.rs` is `pub(super)` — visible only within the `pages` module. Both `parser.rs` and `generator.rs` import from it via `use super::tree::*`.
+
+### Grammar format
+
+One production per line, `LHS -> RHS`:
+- LHS: exactly one uppercase ASCII letter
+- RHS: sequence of uppercase letters (non-terminals) and any other character (terminals)
+- `$` is reserved as the EOF terminal (automatically appended to input)
+- Whitespace in RHS is stripped
+
+Sample grammars are in the repo root: `reducer` (arithmetic) and `paren_reducer` (non-LR(0), used in tests).

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,9 +2,69 @@ use crate::generator_engine::GeneratorEngine;
 use eframe::{App, egui};
 use lr0_parser_rs::grammar::{Grammar, parse_grammar_text};
 use lr0_parser_rs::lr::{self, CompiledParser};
-use lr0_parser_rs::{AstNode, ParseStep, build_trace};
+use lr0_parser_rs::{AstNode, ParseStep, StateInfo, StepAction, build_trace};
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
+
+// ── Parse result types ────────────────────────────────────────────────────────
+
+pub struct ParseArtifacts {
+    pub symbols: Vec<char>,
+    pub table: Vec<Vec<ParseTableAction>>,
+    pub state_infos: Vec<StateInfo>,
+    pub accept_states: Vec<usize>,
+}
+
+pub enum ParserStatus {
+    Empty,
+    Ready(ParseArtifacts),
+}
+
+// ── View models (read-only DTOs for UI rendering) ────────────────────────────
+
+#[derive(Clone)]
+pub struct TraceCursorView {
+    pub cursor: usize,
+    pub total: usize,
+    pub is_playing: bool,
+    pub step: Option<ParseStep>,
+}
+
+#[derive(Clone, Default)]
+pub struct SmHighlightView {
+    pub active_edge: Option<(usize, char, usize)>,
+    pub source_state: Option<usize>,
+    pub result_state: Option<usize>,
+}
+
+impl TraceCursorView {
+    pub fn sm_highlight(&self) -> SmHighlightView {
+        let Some(step) = &self.step else {
+            return SmHighlightView::default();
+        };
+        let active_edge = match &step.action {
+            StepAction::Shift { terminal, to_state } => {
+                Some((step.from_state, *terminal, *to_state))
+            }
+            StepAction::Reduce { .. } | StepAction::Accept => None,
+        };
+        let source_state = Some(step.from_state);
+        let result_state = match &step.action {
+            StepAction::Shift { to_state, .. } => Some(*to_state),
+            StepAction::Reduce { .. } => step.state_stack.last().copied(),
+            StepAction::Accept => None,
+        };
+        SmHighlightView { active_edge, source_state, result_state }
+    }
+}
+
+// ── Page / algorithm enums ────────────────────────────────────────────────────
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Page {
+    Parser,
+    Generator,
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ParserKind {
@@ -46,97 +106,128 @@ impl ParseTableAction {
     }
 }
 
-pub struct ParserApp {
+// ── Sub-state structs ─────────────────────────────────────────────────────────
+
+pub struct UiState {
+    pub current_page: Page,
+    pub fonts_initialized: bool,
+}
+
+pub struct AppServices {
+    pub generator_engine: GeneratorEngine,
+}
+
+pub struct WorkspaceState {
     pub input_string: String,
     pub reducer_string: String,
-    pub parser_result: String,
     pub terminals: Vec<char>,
-    pub current_page: usize,
-    pub generate_result: String,
-    pub generator_ast_preview: String,
-    pub generator_source_preview: String,
-    pub generator_expression_preview: String,
-    pub generator_notes: Vec<String>,
     pub terminal_types: HashMap<char, String>,
-    pub run_result: String,
-    pub generator_engine: GeneratorEngine,
-    pub parse_table: Option<(Vec<char>, Vec<Vec<ParseTableAction>>)>,
+}
 
+pub struct GeneratorPageState {
+    pub generate_result: String,
+    pub ast_preview: String,
+    pub source_preview: String,
+    pub expression_preview: String,
+    pub notes: Vec<String>,
+    pub run_result: String,
+    pub ast: Option<AstNode>,
+}
+
+pub struct ParserPageState {
+    pub result: String,
+    pub selected_kind: ParserKind,
     pub parse_trace: Vec<ParseStep>,
     pub trace_cursor: usize,
     pub anim_playing: bool,
     pub anim_last_advance: Option<Instant>,
-    pub selected_kind: ParserKind,
-    pub generator_ast: Option<AstNode>,
+    pub status: ParserStatus,
+}
+
+// ── App ───────────────────────────────────────────────────────────────────────
+
+pub struct ParserApp {
+    pub ui: UiState,
+    pub services: AppServices,
+    pub workspace: WorkspaceState,
+    pub generator: GeneratorPageState,
+    pub parser: ParserPageState,
 }
 
 impl Default for ParserApp {
     fn default() -> Self {
         Self {
-            input_string: String::new(),
-            reducer_string: String::from("E -> E*B\nE -> E+B\nE -> B\nB -> 0\nB -> 1"),
-            parser_result: String::new(),
-            terminals: vec![],
-            current_page: 0,
-            generate_result: String::new(),
-            generator_ast_preview: String::new(),
-            generator_source_preview: String::new(),
-            generator_expression_preview: String::new(),
-            generator_notes: Vec::new(),
-            terminal_types: HashMap::new(),
-            run_result: String::new(),
-            generator_engine: GeneratorEngine::new(),
-            parse_table: None,
-            parse_trace: Vec::new(),
-            trace_cursor: 0,
-            anim_playing: false,
-            anim_last_advance: None,
-            selected_kind: ParserKind::Lr0,
-            generator_ast: None,
+            ui: UiState {
+                current_page: Page::Parser,
+                fonts_initialized: false,
+            },
+            services: AppServices {
+                generator_engine: GeneratorEngine::new(),
+            },
+            workspace: WorkspaceState {
+                input_string: String::new(),
+                reducer_string: String::from("E -> E*B\nE -> E+B\nE -> B\nB -> 0\nB -> 1"),
+                terminals: vec![],
+                terminal_types: HashMap::new(),
+            },
+            generator: GeneratorPageState {
+                generate_result: String::new(),
+                ast_preview: String::new(),
+                source_preview: String::new(),
+                expression_preview: String::new(),
+                notes: Vec::new(),
+                run_result: String::new(),
+                ast: None,
+            },
+            parser: ParserPageState {
+                result: String::new(),
+                selected_kind: ParserKind::Lr0,
+                parse_trace: Vec::new(),
+                trace_cursor: 0,
+                anim_playing: false,
+                anim_last_advance: None,
+                status: ParserStatus::Empty,
+            },
         }
     }
 }
 
 impl App for ParserApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        if self.anim_playing {
-            if let Some(last) = self.anim_last_advance {
+        if self.parser.anim_playing {
+            if let Some(last) = self.parser.anim_last_advance {
                 if last.elapsed() >= Duration::from_millis(700) {
-                    if self.trace_cursor + 1 < self.parse_trace.len() {
-                        self.trace_cursor += 1;
-                        self.anim_last_advance = Some(Instant::now());
+                    if self.parser.trace_cursor + 1 < self.parser.parse_trace.len() {
+                        self.parser.trace_cursor += 1;
+                        self.parser.anim_last_advance = Some(Instant::now());
                     } else {
-                        self.anim_playing = false;
+                        self.parser.anim_playing = false;
                     }
                 }
             }
             ctx.request_repaint_after(Duration::from_millis(50));
         }
 
-        self.setup_fonts(ctx);
+        if !self.ui.fonts_initialized {
+            self.setup_fonts(ctx);
+            self.ui.fonts_initialized = true;
+        }
+
+        egui::TopBottomPanel::top("app_header")
+            .resizable(false)
+            .show(ctx, |ui| {
+                ui.add_space(10.0);
+                ui.heading("LR(0) Parser GUI");
+                ui.add_space(10.0);
+                self.show_tabs(ui);
+                ui.add_space(10.0);
+            });
 
         egui::CentralPanel::default().show(ctx, |ui| {
-            ui.horizontal(|ui| {
-                ui.add_space(5.0);
-
-                ui.vertical(|ui| {
-                    ui.add_space(10.0);
-                    ui.heading("LR(0) Parser GUI");
-                    ui.add_space(10.0);
-
-                    self.show_tabs(ui);
-
-                    ui.add_space(10.0);
-
-                    match self.current_page {
-                        0 => self.show_parser_page(ui),
-                        1 => self.show_generator_page(ui),
-                        _ => {}
-                    }
-
-                    ui.add_space(10.0);
-                });
-            });
+            match self.ui.current_page {
+                Page::Parser => self.show_parser_page(ui),
+                Page::Generator => self.show_generator_page(ui),
+            }
         });
     }
 }
@@ -173,17 +264,17 @@ impl ParserApp {
     fn show_tabs(&mut self, ui: &mut egui::Ui) {
         ui.horizontal(|ui| {
             if ui
-                .selectable_label(self.current_page == 0, "Parser")
+                .selectable_label(self.ui.current_page == Page::Parser, "Parser")
                 .clicked()
             {
-                self.current_page = 0;
+                self.ui.current_page = Page::Parser;
             }
             if ui
-                .selectable_label(self.current_page == 1, "Generator")
+                .selectable_label(self.ui.current_page == Page::Generator, "Generator")
                 .clicked()
             {
-                self.current_page = 1;
-                self.terminals = parse_grammar_text(&self.reducer_string)
+                self.ui.current_page = Page::Generator;
+                self.workspace.terminals = parse_grammar_text(&self.workspace.reducer_string)
                     .map(|grammar| terminals_from_grammar(&grammar))
                     .unwrap_or_default();
                 self.apply_default_terminal_types();
@@ -192,61 +283,75 @@ impl ParserApp {
     }
 
     pub fn generate_code(&mut self) {
-        self.generator_engine
-            .set_terminal_types(self.terminal_types.clone());
-        match self
+        self.services
             .generator_engine
-            .generate_output(&self.reducer_string, &self.input_string)
+            .set_terminal_types(self.workspace.terminal_types.clone());
+        match self
+            .services
+            .generator_engine
+            .generate_output(&self.workspace.reducer_string, &self.workspace.input_string)
         {
             Ok(output) => {
-                self.generator_ast_preview = output.ast_preview;
-                self.generator_ast = output.ast;
-                self.generator_source_preview = output.source_preview;
-                self.generator_expression_preview =
+                self.generator.ast_preview = output.ast_preview;
+                self.generator.ast = output.ast;
+                self.generator.source_preview = output.source_preview;
+                self.generator.expression_preview =
                     output.evaluation_expression.unwrap_or_else(|| "<not available>".to_string());
-                self.generator_notes = output.notes;
-                self.generate_result = output.generated_code;
-                self.run_result.clear();
+                self.generator.notes = output.notes;
+                self.generator.generate_result = output.generated_code;
+                self.generator.run_result.clear();
             }
             Err(err) => {
-                self.generator_ast_preview.clear();
-                self.generator_ast = None;
-                self.generator_source_preview.clear();
-                self.generator_expression_preview.clear();
-                self.generator_notes = vec![err.clone()];
-                self.generate_result = err;
-                self.run_result.clear();
+                self.generator.ast_preview.clear();
+                self.generator.ast = None;
+                self.generator.source_preview.clear();
+                self.generator.expression_preview.clear();
+                self.generator.notes = vec![err.clone()];
+                self.generator.generate_result = err;
+                self.generator.run_result.clear();
             }
         }
     }
 
     pub fn run_rust_code(&mut self) {
-        self.run_result = crate::generator_engine::run_generated_code(&self.generate_result);
+        let code = self.generator.generate_result.clone();
+        self.generator.run_result = crate::generator_engine::run_generated_code(&code);
     }
 
     pub fn apply_default_terminal_types(&mut self) {
-        for &terminal in &self.terminals {
-            self.terminal_types
+        for &terminal in &self.workspace.terminals {
+            self.workspace
+                .terminal_types
                 .entry(terminal)
                 .or_insert_with(|| default_terminal_role(terminal).to_string());
         }
     }
 
+    pub fn cursor_view(&self) -> TraceCursorView {
+        TraceCursorView {
+            cursor: self.parser.trace_cursor,
+            total: self.parser.parse_trace.len(),
+            is_playing: self.parser.anim_playing,
+            step: self.parser.parse_trace.get(self.parser.trace_cursor).cloned(),
+        }
+    }
+
     pub fn step_to(&mut self, cursor: usize) {
-        self.trace_cursor = cursor.min(self.parse_trace.len().saturating_sub(1));
-        self.anim_playing = false;
+        self.parser.trace_cursor =
+            cursor.min(self.parser.parse_trace.len().saturating_sub(1));
+        self.parser.anim_playing = false;
     }
 
     pub fn toggle_play(&mut self) {
-        if self.parse_trace.is_empty() {
+        if self.parser.parse_trace.is_empty() {
             return;
         }
-        self.anim_playing = !self.anim_playing;
-        if self.anim_playing {
-            if self.trace_cursor + 1 >= self.parse_trace.len() {
-                self.trace_cursor = 0;
+        self.parser.anim_playing = !self.parser.anim_playing;
+        if self.parser.anim_playing {
+            if self.parser.trace_cursor + 1 >= self.parser.parse_trace.len() {
+                self.parser.trace_cursor = 0;
             }
-            self.anim_last_advance = Some(Instant::now());
+            self.parser.anim_last_advance = Some(Instant::now());
         }
     }
 }
@@ -277,7 +382,8 @@ pub fn build_parse_table(
     grammar: &Grammar,
     compiled_parser: &CompiledParser,
 ) -> (Vec<char>, Vec<Vec<ParseTableAction>>) {
-    let mut symbols: Vec<char> = grammar.terminals().into_iter().map(|terminal| terminal.0).collect();
+    let mut symbols: Vec<char> =
+        grammar.terminals().into_iter().map(|terminal| terminal.0).collect();
     if !symbols.contains(&'$') {
         symbols.push('$');
     }
@@ -288,7 +394,8 @@ pub fn build_parse_table(
             .map(|non_terminal| non_terminal.0),
     );
 
-    let mut table = vec![vec![ParseTableAction::Error; symbols.len()]; compiled_parser.state_count()];
+    let mut table =
+        vec![vec![ParseTableAction::Error; symbols.len()]; compiled_parser.state_count()];
 
     for state in 0..compiled_parser.state_count() {
         for (column, symbol) in symbols.iter().copied().enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod lr;
 pub mod runtime;
 
 pub use ast::AstNode;
+pub use lr::{LrItem, StateInfo};
 pub use runtime::{ParseStep, StepAction, build_trace};
 
 #[cfg(test)]

--- a/src/lr.rs
+++ b/src/lr.rs
@@ -114,12 +114,26 @@ pub fn compile(grammar: &Grammar) -> Result<CompiledParser, ParserError> {
         }
     }
 
+    let state_infos: Vec<StateInfo> = item_sets.iter().enumerate().map(|(id, item_set)| {
+        let items = item_set.iter().map(|item| LrItem {
+            production: item.production.clone(),
+            dot_pos: item.dot_pos,
+        }).collect();
+        let mut transitions: Vec<(Symbol, usize)> = edges.iter()
+            .filter(|((state, _), _)| *state == id)
+            .map(|((_, sym), &next)| (sym.clone(), next))
+            .collect();
+        transitions.sort_by(|a, b| a.0.cmp(&b.0));
+        StateInfo { id, items, transitions }
+    }).collect();
+
     Ok(CompiledParser {
         productions,
         action_table,
         goto_table,
         start_state: 0,
         state_count: item_sets.len(),
+        state_infos,
     })
 }
 
@@ -223,12 +237,26 @@ struct Item {
 pub type InternalState = usize;
 type ProductionId = usize;
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LrItem {
+    pub production: Production,
+    pub dot_pos: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInfo {
+    pub id: usize,
+    pub items: Vec<LrItem>,
+    pub transitions: Vec<(Symbol, usize)>,
+}
+
 pub struct CompiledParser {
     productions: Vec<Production>,
     action_table: BTreeMap<(InternalState, Terminal), Action>,
     goto_table: BTreeMap<(InternalState, NonTerminal), InternalState>,
     start_state: InternalState,
     state_count: usize,
+    state_infos: Vec<StateInfo>,
 }
 
 impl CompiledParser {
@@ -254,6 +282,10 @@ impl CompiledParser {
 
     pub fn state_count(&self) -> usize {
         self.state_count
+    }
+
+    pub fn state_infos(&self) -> &[StateInfo] {
+        &self.state_infos
     }
 }
 

--- a/src/pages/generator.rs
+++ b/src/pages/generator.rs
@@ -4,17 +4,14 @@ use super::tree::{draw_tree, layout_ast, tree_pixel_height, NODE_R};
 
 impl ParserApp {
     pub fn show_generator_page(&mut self, ui: &mut egui::Ui) {
-        let avail_h = ui.available_height();
-        let left_w = ui.available_width() * 0.36;
-
-        ui.horizontal_top(|ui| {
-            // ── 左列 ──────────────────────────────────────────────
-            ui.vertical(|ui| {
-                ui.set_width(left_w);
-                egui::ScrollArea::vertical()
-                    .id_salt("gen_left_scroll")
-                    .max_height(avail_h)
-                    .show(ui, |ui| {
+        egui::ScrollArea::vertical()
+            .id_salt("gen_page_scroll")
+            .show(ui, |ui| {
+                let left_w = ui.available_width() * 0.36;
+                ui.horizontal_top(|ui| {
+                    // ── 左列 ──────────────────────────────────────────────
+                    ui.vertical(|ui| {
+                        ui.set_width(left_w);
                         ui.add_space(12.0);
                         ui.label(egui::RichText::new("Terminal Roles").size(18.0).strong());
                         ui.label(
@@ -26,7 +23,7 @@ impl ParserApp {
                         );
                         ui.add_space(10.0);
 
-                        if self.terminals.is_empty() {
+                        if self.workspace.terminals.is_empty() {
                             ui.add(
                                 egui::Label::new(
                                     egui::RichText::new(
@@ -38,7 +35,7 @@ impl ParserApp {
                                 .wrap(),
                             );
                         } else {
-                            let terminals = self.terminals.clone();
+                            let terminals = self.workspace.terminals.clone();
                             for (index, symbol) in terminals.iter().enumerate() {
                                 ui.horizontal(|ui| {
                                     ui.label(
@@ -62,7 +59,7 @@ impl ParserApp {
                         ui.add_space(16.0);
                         ui.label(egui::RichText::new("Target String").size(18.0).strong());
                         ui.add_space(8.0);
-                        ui.text_edit_singleline(&mut self.input_string);
+                        ui.text_edit_singleline(&mut self.workspace.input_string);
 
                         ui.add_space(16.0);
                         if ui
@@ -83,7 +80,7 @@ impl ParserApp {
                         ui.add_space(16.0);
                         ui.label(egui::RichText::new("Notes").size(18.0).strong());
                         ui.add_space(8.0);
-                        if self.generator_notes.is_empty() {
+                        if self.generator.notes.is_empty() {
                             ui.label(
                                 egui::RichText::new(
                                     "No notes yet. Generate code to see validation hints.",
@@ -92,7 +89,7 @@ impl ParserApp {
                                 .color(egui::Color32::GRAY),
                             );
                         } else {
-                            for note in &self.generator_notes {
+                            for note in &self.generator.notes {
                                 ui.label(
                                     egui::RichText::new(format!("- {}", note))
                                         .size(13.0)
@@ -101,95 +98,84 @@ impl ParserApp {
                             }
                         }
                     });
-            });
 
-            ui.add_space(18.0);
+                    ui.add_space(18.0);
 
-            // ── 右列 ──────────────────────────────────────────────
-            egui::ScrollArea::vertical()
-                .id_salt("gen_right_scroll")
-                .max_height(avail_h)
-                .show(ui, |ui| {
-                    ui.add_space(12.0);
-                    ui.label(egui::RichText::new("Generation Summary").size(18.0).strong());
-                    ui.add_space(8.0);
+                    // ── 右列 ──────────────────────────────────────────────
+                    ui.vertical(|ui| {
+                        ui.set_min_width(ui.available_width());
+                        ui.add_space(12.0);
+                        ui.label(egui::RichText::new("Generation Summary").size(18.0).strong());
+                        ui.add_space(8.0);
 
-                    // AST Preview
-                    ui.label(
-                        egui::RichText::new("AST Preview")
-                            .size(14.0)
-                            .strong()
-                            .color(egui::Color32::from_rgb(190, 190, 210)),
-                    );
-                    ui.add_space(6.0);
-                    if let Some(ast) = self.generator_ast.clone() {
-                        let layout = layout_ast(&ast);
-                        let tree_w = layout.subtree_width.max(60.0);
-                        let tree_h = tree_pixel_height(&layout) + NODE_R * 2.0 + 4.0;
-                        egui::Frame::group(ui.style()).show(ui, |ui| {
-                            ui.set_min_width(ui.available_width());
-                            egui::ScrollArea::both()
-                                .id_salt("gen_ast_scroll")
-                                .max_height(150.0)
-                                .show(ui, |ui| {
-                                    let size = egui::Vec2::new(tree_w, tree_h);
-                                    let (rect, _) =
-                                        ui.allocate_exact_size(size, egui::Sense::hover());
-                                    if ui.is_rect_visible(rect) {
-                                        draw_tree(
-                                            ui.painter(),
-                                            rect.min + egui::Vec2::new(0.0, NODE_R),
-                                            &layout,
-                                        );
-                                    }
-                                });
-                        });
-                    } else {
-                        egui::Frame::group(ui.style()).show(ui, |ui| {
-                            ui.set_min_width(ui.available_width());
-                            ui.label(
-                                egui::RichText::new("Nothing yet.")
-                                    .size(13.0)
-                                    .color(egui::Color32::GRAY),
-                            );
-                        });
-                    }
+                        ui.label(
+                            egui::RichText::new("AST Preview")
+                                .size(14.0)
+                                .strong()
+                                .color(egui::Color32::from_rgb(190, 190, 210)),
+                        );
+                        ui.add_space(6.0);
+                        if let Some(ast) = self.generator.ast.clone() {
+                            let layout = layout_ast(&ast);
+                            let tree_w = layout.subtree_width.max(60.0);
+                            let tree_h = tree_pixel_height(&layout) + NODE_R * 2.0 + 4.0;
+                            egui::Frame::group(ui.style()).show(ui, |ui| {
+                                ui.set_min_width(ui.available_width());
+                                egui::ScrollArea::both()
+                                    .id_salt("gen_ast_scroll")
+                                    .max_height(tree_h)
+                                    .show(ui, |ui| {
+                                        let size = egui::Vec2::new(tree_w, tree_h);
+                                        let (rect, _) =
+                                            ui.allocate_exact_size(size, egui::Sense::hover());
+                                        if ui.is_rect_visible(rect) {
+                                            draw_tree(
+                                                ui.painter(),
+                                                rect.min + egui::Vec2::new(0.0, NODE_R),
+                                                &layout,
+                                            );
+                                        }
+                                    });
+                            });
+                        } else {
+                            egui::Frame::group(ui.style()).show(ui, |ui| {
+                                ui.set_min_width(ui.available_width());
+                                ui.label(
+                                    egui::RichText::new("Nothing yet.")
+                                        .size(13.0)
+                                        .color(egui::Color32::GRAY),
+                                );
+                            });
+                        }
 
-                    ui.add_space(10.0);
-                    self.show_preview_card(
-                        ui,
-                        "Reconstructed Source",
-                        &self.generator_source_preview.clone(),
-                        60.0,
-                    );
-                    ui.add_space(10.0);
-                    self.show_preview_card(
-                        ui,
-                        "Evaluation Expression",
-                        &self.generator_expression_preview.clone(),
-                        60.0,
-                    );
+                        ui.add_space(10.0);
+                        self.show_preview_card(
+                            ui,
+                            "Reconstructed Source",
+                            &self.generator.source_preview.clone(),
+                        );
+                        ui.add_space(10.0);
+                        self.show_preview_card(
+                            ui,
+                            "Evaluation Expression",
+                            &self.generator.expression_preview.clone(),
+                        );
 
-                    ui.add_space(14.0);
-                    ui.label(egui::RichText::new("Generated Rust Code").size(18.0).strong());
-                    ui.add_space(8.0);
-                    self.show_preview_card(ui, "Code", &self.generate_result.clone(), 200.0);
+                        ui.add_space(14.0);
+                        ui.label(egui::RichText::new("Generated Rust Code").size(18.0).strong());
+                        ui.add_space(8.0);
+                        self.show_preview_card(ui, "Code", &self.generator.generate_result.clone());
 
-                    ui.add_space(14.0);
-                    ui.label(egui::RichText::new("Execution Result").size(18.0).strong());
-                    ui.add_space(8.0);
-                    self.show_preview_card(ui, "Run", &self.run_result.clone(), 150.0);
+                        ui.add_space(14.0);
+                        ui.label(egui::RichText::new("Execution Result").size(18.0).strong());
+                        ui.add_space(8.0);
+                        self.show_preview_card(ui, "Run", &self.generator.run_result.clone());
+                    });
                 });
-        });
+            });
     }
 
-    fn show_preview_card(
-        &self,
-        ui: &mut egui::Ui,
-        label: &str,
-        content: &str,
-        max_height: f32,
-    ) {
+    fn show_preview_card(&self, ui: &mut egui::Ui, label: &str, content: &str) {
         egui::Frame::group(ui.style()).show(ui, |ui| {
             ui.set_min_width(ui.available_width());
             ui.label(
@@ -199,33 +185,31 @@ impl ParserApp {
                     .color(egui::Color32::from_rgb(190, 190, 210)),
             );
             ui.add_space(6.0);
-            egui::ScrollArea::vertical()
-                .id_salt(format!("{}_scroll", label))
-                .max_height(max_height)
-                .show(ui, |ui| {
-                    if content.trim().is_empty() {
-                        ui.label(
-                            egui::RichText::new("Nothing yet.")
-                                .size(13.0)
-                                .color(egui::Color32::GRAY),
-                        );
-                    } else {
+            if content.trim().is_empty() {
+                ui.label(
+                    egui::RichText::new("Nothing yet.")
+                        .size(13.0)
+                        .color(egui::Color32::GRAY),
+                );
+            } else {
+                egui::ScrollArea::vertical()
+                    .id_salt(format!("preview_card_{}", label))
+                    .max_height(240.0)
+                    .show(ui, |ui| {
                         ui.add(
                             egui::Label::new(
-                                egui::RichText::new(content)
-                                    .monospace()
-                                    .size(12.5),
+                                egui::RichText::new(content).monospace().size(12.5),
                             )
                             .wrap(),
                         );
-                    }
-                });
+                    });
+            }
         });
     }
 
     fn show_terminal_dropdown(&mut self, ui: &mut egui::Ui, symbol: char) {
         let current_selection = self
-            .terminal_types
+            .workspace.terminal_types
             .get(&symbol)
             .unwrap_or(&"Token".to_string())
             .clone();
@@ -239,7 +223,7 @@ impl ParserApp {
                 ];
                 for option in &options {
                     ui.selectable_value(
-                        self.terminal_types
+                        self.workspace.terminal_types
                             .entry(symbol)
                             .or_insert_with(|| "Token".to_string()),
                         option.to_string(),

--- a/src/pages/parser.rs
+++ b/src/pages/parser.rs
@@ -2,13 +2,14 @@ use eframe::egui;
 use lr0_parser_rs::grammar::{Grammar, GrammarError, Symbol, parse_grammar_text, parse_input_text};
 use lr0_parser_rs::lr::{CompiledParser, ParserError, compile};
 use lr0_parser_rs::runtime::{RuntimeError, run};
-use lr0_parser_rs::StepAction;
+use lr0_parser_rs::{StateInfo, StepAction};
 use std::fmt;
 use super::tree::{draw_tree, layout_ast, tree_pixel_height, H_GAP, NODE_R};
 
 use crate::app::{
-    ParseTableAction, ParserApp, ParserKind, build_animation_trace, build_parse_table,
-    terminals_from_grammar,
+    ParseArtifacts, ParseTableAction, ParserApp, ParserKind, ParserStatus,
+    SmHighlightView, TraceCursorView,
+    build_animation_trace, build_parse_table, terminals_from_grammar,
 };
 use crate::validation::Validation;
 
@@ -123,217 +124,214 @@ fn validate_input(input_text: &str) -> Validation<ParsePreparationError, Vec<Sym
 
 impl ParserApp {
     pub fn show_parser_page(&mut self, ui: &mut egui::Ui) {
-        let avail_h = ui.available_height();
-        let top_row_h = (avail_h * 0.40).max(220.0);
-        let ast_row_h = (avail_h * 0.22).max(120.0);
+        let left_w = ui.available_width() * 0.42;
+        let view = self.cursor_view();
 
-        ui.vertical(|ui| {
-            ui.horizontal(|ui| {
-                self.show_input_panel(ui, top_row_h);
-                ui.add_space(15.0);
-                self.show_trace_panel(ui, top_row_h);
-            });
-
-            ui.add_space(8.0);
-            self.show_ast_formation_section(ui, ast_row_h);
-
-            ui.add_space(8.0);
-            self.show_parse_table_section(ui);
-        });
-    }
-
-    fn show_input_panel(&mut self, ui: &mut egui::Ui, panel_h: f32) {
-        let text_h = (panel_h * 0.45).max(80.0);
-        ui.allocate_ui_with_layout(
-            egui::Vec2::new(ui.available_width() * 0.35, panel_h),
-            egui::Layout::top_down(egui::Align::LEFT),
-            |ui| {
-                ui.add_space(10.0);
-                ui.horizontal(|ui| {
-                    ui.label(egui::RichText::new("Algorithm:").size(14.0));
-                    for kind in [ParserKind::Lr0, ParserKind::Slr, ParserKind::Lalr, ParserKind::Lr1] {
-                        if ui.selectable_label(self.selected_kind == kind, kind.label()).clicked() {
-                            self.selected_kind = kind;
-                        }
-                    }
-                });
-                ui.add_space(8.0);
-                ui.label(egui::RichText::new("Production:").size(16.0));
-                ui.add_space(5.0);
-
-                egui::ScrollArea::vertical()
-                    .id_salt("production_scroll")
-                    .min_scrolled_height(text_h)
-                    .max_height(text_h)
-                    .show(ui, |ui| {
-                        ui.text_edit_multiline(&mut self.reducer_string);
+        egui::ScrollArea::vertical()
+            .id_salt("parser_page_scroll")
+            .show(ui, |ui| {
+                ui.horizontal_top(|ui| {
+                    // ── 左列: Input + Parse Table ──────────────────────
+                    ui.vertical(|ui| {
+                        ui.set_width(left_w);
+                        self.show_input_panel(ui, 180.0);
+                        ui.add_space(12.0);
+                        self.show_parse_table_panel(ui, 300.0, &view);
                     });
 
-                ui.add_space(15.0);
-                ui.label(egui::RichText::new("Target String:").size(16.0));
-                ui.add_space(5.0);
-                ui.text_edit_singleline(&mut self.input_string);
-
-                ui.add_space(15.0);
-                if ui.button(egui::RichText::new("Parse").size(16.0)).clicked() {
-                    self.handle_parse();
-                }
-
-                if !self.parser_result.is_empty() {
-                    ui.add_space(8.0);
-                    ui.label(
-                        egui::RichText::new(&self.parser_result)
-                            .color(egui::Color32::from_rgb(220, 80, 80))
-                            .size(13.0),
-                    );
-                }
-            },
-        );
-    }
-
-    fn show_trace_panel(&mut self, ui: &mut egui::Ui, panel_h: f32) {
-        ui.allocate_ui_with_layout(
-            egui::Vec2::new(ui.available_width(), panel_h),
-            egui::Layout::top_down(egui::Align::LEFT),
-            |ui| {
-                ui.add_space(10.0);
-                ui.label(egui::RichText::new("Parse Trace:").size(16.0));
-                ui.add_space(8.0);
-
-                if self.parse_trace.is_empty() {
-                    ui.label(
-                        egui::RichText::new("No trace yet. Parse a grammar and input first.")
-                            .color(egui::Color32::GRAY)
-                            .size(13.0),
-                    );
-                    return;
-                }
-
-                let total = self.parse_trace.len();
-                let cursor = self.trace_cursor;
-
-                // ── Step counter + nav controls ──────────────────────────
-                ui.horizontal(|ui| {
-                    ui.label(
-                        egui::RichText::new(format!("Step {} / {}", cursor + 1, total))
-                            .size(13.0)
-                            .strong(),
-                    );
                     ui.add_space(12.0);
 
-                    if ui.button("|<").clicked() {
-                        self.step_to(0);
-                    }
-                    if ui.button(" < ").clicked() && cursor > 0 {
-                        self.step_to(cursor - 1);
-                    }
-
-                    let play_label = if self.anim_playing { "⏸" } else { "▶" };
-                    if ui.button(play_label).clicked() {
-                        self.toggle_play();
-                    }
-
-                    if ui.button(" > ").clicked() && cursor + 1 < total {
-                        self.step_to(cursor + 1);
-                    }
-                    if ui.button(">|").clicked() {
-                        self.step_to(total - 1);
-                    }
-                });
-
-                ui.add_space(10.0);
-
-                let step = &self.parse_trace[cursor];
-
-                // ── Action label ─────────────────────────────────────────
-                let (action_text, action_color) = render_action_label(&step.action);
-                ui.horizontal(|ui| {
-                    ui.label(egui::RichText::new("Action: ").size(14.0).strong());
-                    ui.label(
-                        egui::RichText::new(&action_text)
-                            .monospace()
-                            .size(14.0)
-                            .color(action_color),
-                    );
-                });
-
-                ui.add_space(10.0);
-
-                // ── State stack + remaining input ─────────────────────────
-                ui.horizontal(|ui| {
+                    // ── 右列: Trace + AST Formation + State Machine ────
                     ui.vertical(|ui| {
-                        ui.label(egui::RichText::new("State Stack").size(12.0).strong());
-                        ui.add_space(4.0);
-                        ui.horizontal(|ui| {
-                            for (i, &s) in step.state_stack.iter().enumerate() {
-                                let is_top = i + 1 == step.state_stack.len();
-                                let color = if is_top {
-                                    egui::Color32::from_rgb(80, 160, 220)
-                                } else {
-                                    egui::Color32::from_rgb(130, 130, 130)
-                                };
-                                ui.label(
-                                    egui::RichText::new(format!("[{}]", s))
-                                        .monospace()
-                                        .size(13.0)
-                                        .color(color),
-                                );
-                            }
-                            if step.state_stack.is_empty() {
-                                ui.label(
-                                    egui::RichText::new("(empty)")
-                                        .monospace()
-                                        .size(13.0)
-                                        .color(egui::Color32::GRAY),
-                                );
-                            }
-                        });
-                    });
-
-                    ui.add_space(20.0);
-
-                    ui.vertical(|ui| {
-                        ui.label(egui::RichText::new("Remaining Input").size(12.0).strong());
-                        ui.add_space(4.0);
-                        ui.horizontal(|ui| {
-                            for (i, &c) in step.remaining_input.iter().enumerate() {
-                                let is_head = i == 0;
-                                let color = if is_head {
-                                    egui::Color32::from_rgb(240, 180, 60)
-                                } else {
-                                    egui::Color32::from_rgb(180, 180, 180)
-                                };
-                                ui.label(
-                                    egui::RichText::new(c.to_string())
-                                        .monospace()
-                                        .size(14.0)
-                                        .color(color),
-                                );
-                                ui.add_space(4.0);
-                            }
-                            if step.remaining_input.is_empty() {
-                                ui.label(
-                                    egui::RichText::new("(empty)")
-                                        .monospace()
-                                        .size(13.0)
-                                        .color(egui::Color32::GRAY),
-                                );
-                            }
-                        });
+                        ui.set_min_width(ui.available_width());
+                        self.show_trace_panel(ui, &view);
+                        if view.total > 0 {
+                            ui.add_space(12.0);
+                            self.show_ast_formation_section(ui, &view);
+                        }
+                        ui.add_space(12.0);
+                        self.show_state_machine_panel(ui, &view);
                     });
                 });
-
-            },
-        );
+            });
     }
 
-    fn show_ast_formation_section(&self, ui: &mut egui::Ui, panel_h: f32) {
-        if self.parse_trace.is_empty() {
+    fn show_input_panel(&mut self, ui: &mut egui::Ui, text_h: f32) {
+        ui.add_space(10.0);
+        ui.horizontal(|ui| {
+            ui.label(egui::RichText::new("Algorithm:").size(14.0));
+            for kind in [ParserKind::Lr0, ParserKind::Slr, ParserKind::Lalr, ParserKind::Lr1] {
+                if ui.selectable_label(self.parser.selected_kind == kind, kind.label()).clicked() {
+                    self.parser.selected_kind = kind;
+                }
+            }
+        });
+        ui.add_space(8.0);
+        ui.label(egui::RichText::new("Production:").size(16.0));
+        ui.add_space(5.0);
+
+        egui::ScrollArea::vertical()
+            .id_salt("production_scroll")
+            .min_scrolled_height(text_h)
+            .max_height(text_h)
+            .show(ui, |ui| {
+                ui.add(
+                    egui::TextEdit::multiline(&mut self.workspace.reducer_string)
+                        .desired_width(f32::INFINITY),
+                );
+            });
+
+        ui.add_space(12.0);
+        ui.label(egui::RichText::new("Target String:").size(16.0));
+        ui.add_space(5.0);
+        ui.text_edit_singleline(&mut self.workspace.input_string);
+
+        ui.add_space(12.0);
+        if ui.button(egui::RichText::new("Parse").size(16.0)).clicked() {
+            self.handle_parse();
+        }
+
+        if !self.parser.result.is_empty() {
+            ui.add_space(8.0);
+            ui.label(
+                egui::RichText::new(&self.parser.result)
+                    .color(egui::Color32::from_rgb(220, 80, 80))
+                    .size(13.0),
+            );
+        }
+    }
+
+    fn show_trace_panel(&mut self, ui: &mut egui::Ui, view: &TraceCursorView) {
+        ui.add_space(10.0);
+        ui.label(egui::RichText::new("Parse Trace:").size(16.0));
+        ui.add_space(8.0);
+
+        if view.total == 0 {
+            ui.label(
+                egui::RichText::new("No trace yet. Parse a grammar and input first.")
+                    .color(egui::Color32::GRAY)
+                    .size(13.0),
+            );
             return;
         }
 
-        let step = &self.parse_trace[self.trace_cursor];
-        let total = self.parse_trace.len();
+        let cursor = view.cursor;
+        let total = view.total;
+
+        // ── Step counter + nav controls ──────────────────────────────────
+        ui.horizontal(|ui| {
+            ui.label(
+                egui::RichText::new(format!("Step {} / {}", cursor + 1, total))
+                    .size(13.0)
+                    .strong(),
+            );
+            ui.add_space(12.0);
+
+            if ui.button("|<").clicked() {
+                self.step_to(0);
+            }
+            if ui.button(" < ").clicked() && cursor > 0 {
+                self.step_to(cursor - 1);
+            }
+
+            let play_label = if view.is_playing { "⏸" } else { "▶" };
+            if ui.button(play_label).clicked() {
+                self.toggle_play();
+            }
+
+            if ui.button(" > ").clicked() && cursor + 1 < total {
+                self.step_to(cursor + 1);
+            }
+            if ui.button(">|").clicked() {
+                self.step_to(total - 1);
+            }
+        });
+
+        ui.add_space(10.0);
+
+        let Some(step) = &view.step else { return; };
+
+        // ── Action label ──────────────────────────────────────────────────
+        let (action_text, action_color) = render_action_label(&step.action);
+        ui.horizontal(|ui| {
+            ui.label(egui::RichText::new("Action: ").size(14.0).strong());
+            ui.label(
+                egui::RichText::new(&action_text)
+                    .monospace()
+                    .size(14.0)
+                    .color(action_color),
+            );
+        });
+
+        ui.add_space(10.0);
+
+        // ── State stack + remaining input ─────────────────────────────────
+        ui.horizontal(|ui| {
+            ui.vertical(|ui| {
+                ui.label(egui::RichText::new("State Stack").size(12.0).strong());
+                ui.add_space(4.0);
+                ui.horizontal(|ui| {
+                    for (i, &s) in step.state_stack.iter().enumerate() {
+                        let is_top = i + 1 == step.state_stack.len();
+                        let color = if is_top {
+                            egui::Color32::from_rgb(80, 160, 220)
+                        } else {
+                            egui::Color32::from_rgb(130, 130, 130)
+                        };
+                        ui.label(
+                            egui::RichText::new(format!("[{}]", s))
+                                .monospace()
+                                .size(13.0)
+                                .color(color),
+                        );
+                    }
+                    if step.state_stack.is_empty() {
+                        ui.label(
+                            egui::RichText::new("(empty)")
+                                .monospace()
+                                .size(13.0)
+                                .color(egui::Color32::GRAY),
+                        );
+                    }
+                });
+            });
+
+            ui.add_space(20.0);
+
+            ui.vertical(|ui| {
+                ui.label(egui::RichText::new("Remaining Input").size(12.0).strong());
+                ui.add_space(4.0);
+                ui.horizontal(|ui| {
+                    for (i, &c) in step.remaining_input.iter().enumerate() {
+                        let is_head = i == 0;
+                        let color = if is_head {
+                            egui::Color32::from_rgb(240, 180, 60)
+                        } else {
+                            egui::Color32::from_rgb(180, 180, 180)
+                        };
+                        ui.label(
+                            egui::RichText::new(c.to_string())
+                                .monospace()
+                                .size(14.0)
+                                .color(color),
+                        );
+                        ui.add_space(4.0);
+                    }
+                    if step.remaining_input.is_empty() {
+                        ui.label(
+                            egui::RichText::new("(empty)")
+                                .monospace()
+                                .size(13.0)
+                                .color(egui::Color32::GRAY),
+                        );
+                    }
+                });
+            });
+        });
+    }
+
+    fn show_ast_formation_section(&self, ui: &mut egui::Ui, view: &TraceCursorView) {
+        let Some(step) = &view.step else { return; };
 
         ui.horizontal(|ui| {
             ui.label(egui::RichText::new("AST Formation:").size(16.0));
@@ -341,8 +339,8 @@ impl ParserApp {
             ui.label(
                 egui::RichText::new(format!(
                     "Step {} / {}",
-                    self.trace_cursor + 1,
-                    total
+                    view.cursor + 1,
+                    view.total
                 ))
                 .size(13.0)
                 .color(egui::Color32::GRAY),
@@ -353,7 +351,7 @@ impl ParserApp {
         egui::ScrollArea::horizontal()
             .id_salt("ast_formation_hscroll")
             .show(ui, |ui| {
-                ui.set_min_height(panel_h);
+                ui.set_min_height(140.0);
                 ui.horizontal_top(|ui| {
                     if step.ast_stack.is_empty() {
                         ui.label(
@@ -408,7 +406,7 @@ impl ParserApp {
             });
     }
 
-    fn show_parse_table_section(&self, ui: &mut egui::Ui) {
+    fn show_parse_table_panel(&self, ui: &mut egui::Ui, table_h: f32, view: &TraceCursorView) {
         ui.label(egui::RichText::new("Parse Table:").size(16.0));
         ui.add_space(5.0);
 
@@ -431,15 +429,137 @@ impl ParserApp {
         });
         ui.add_space(5.0);
 
-        let highlight = self.parse_trace.get(self.trace_cursor).map(|step| {
-            (step.from_state, step.lookahead)
-        });
+        let highlight = view.step.as_ref().map(|step| (step.from_state, step.lookahead));
 
-        if let Some((symbols, table)) = &self.parse_table {
-            self.show_parse_table(ui, symbols, table, highlight);
+        if let ParserStatus::Ready(artifacts) = &self.parser.status {
+            self.show_parse_table(ui, &artifacts.symbols, &artifacts.table, highlight, table_h);
         } else {
-            ui.label("No parse table available. Please parse a grammar first.");
+            ui.label(
+                egui::RichText::new("No parse table yet. Parse a grammar first.")
+                    .size(13.0)
+                    .color(egui::Color32::GRAY),
+            );
         }
+    }
+
+    fn show_state_machine_panel(&self, ui: &mut egui::Ui, view: &TraceCursorView) {
+        ui.label(egui::RichText::new("State Machine:").size(16.0));
+        ui.add_space(5.0);
+
+        // ── Trace Debug panel ─────────────────────────────────────────────
+        egui::CollapsingHeader::new(egui::RichText::new("Trace Debug").size(13.0))
+            .id_salt("sm_trace_debug")
+            .default_open(false)
+            .show(ui, |ui| {
+                if let Some(step) = &view.step {
+                    // Row 1: cursor + action summary
+                    let action_str = match &step.action {
+                        StepAction::Shift { terminal, to_state } =>
+                            format!("SHIFT '{}' -> {}", terminal, to_state),
+                        StepAction::Reduce { rule, pop_count } =>
+                            format!("REDUCE {} (pop {})", rule, pop_count),
+                        StepAction::Accept =>
+                            "ACCEPT".to_string(),
+                    };
+                    ui.label(
+                        egui::RichText::new(format!(
+                            "cursor={}/{}  action={}",
+                            view.cursor + 1, view.total, action_str
+                        ))
+                        .monospace()
+                        .size(11.5),
+                    );
+
+                    // Row 2: decision context (pre-action)
+                    ui.label(
+                        egui::RichText::new(format!(
+                            "Decision: from_state={}  lookahead='{}'",
+                            step.from_state, step.lookahead
+                        ))
+                        .monospace()
+                        .size(11.5)
+                        .color(egui::Color32::from_rgb(160, 200, 255)),
+                    );
+
+                    // Row 3: post-action snapshot
+                    let stack_str = step.state_stack.iter()
+                        .map(|s| s.to_string())
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    let remaining_str: String = step.remaining_input.iter().collect();
+                    let stack_top = step.state_stack.last().map(|s| s.to_string())
+                        .unwrap_or_else(|| "-".to_string());
+                    ui.label(
+                        egui::RichText::new(format!(
+                            "Post:  stack_top={}  stack=[{}]  remaining='{}'",
+                            stack_top, stack_str, remaining_str
+                        ))
+                        .monospace()
+                        .size(11.5)
+                        .color(egui::Color32::from_rgb(200, 255, 180)),
+                    );
+
+                    // Row 4: SM edge implication
+                    let sm_edge_str = match &step.action {
+                        StepAction::Shift { terminal, to_state } =>
+                            format!("sm_edge: {} -'{}'-> {}", step.from_state, terminal, to_state),
+                        StepAction::Reduce { rule, .. } =>
+                            format!("sm_edge: <none — reduce {}; Goto happens next>", rule),
+                        StepAction::Accept =>
+                            format!("sm_edge: <none — accept at state {}>", step.from_state),
+                    };
+                    ui.label(
+                        egui::RichText::new(sm_edge_str)
+                        .monospace()
+                        .size(11.5)
+                        .color(egui::Color32::from_rgb(255, 220, 130)),
+                    );
+                } else {
+                    ui.label(
+                        egui::RichText::new("No trace. Parse first.")
+                            .size(11.5)
+                            .color(egui::Color32::GRAY),
+                    );
+                }
+            });
+        ui.add_space(5.0);
+        // ─────────────────────────────────────────────────────────────────
+
+        let ParserStatus::Ready(artifacts) = &self.parser.status else {
+            egui::Frame::group(ui.style()).show(ui, |ui| {
+                ui.set_min_width(ui.available_width());
+                ui.label(
+                    egui::RichText::new("No state info yet. Parse a grammar first.")
+                        .size(13.0)
+                        .color(egui::Color32::GRAY),
+                );
+            });
+            return;
+        };
+
+        let sm_highlight = view.sm_highlight();
+        let (nodes, total_w, total_h) = layout_sm(&artifacts.state_infos);
+
+        egui::Frame::group(ui.style()).show(ui, |ui| {
+            ui.set_min_width(ui.available_width());
+            // Horizontal scroll only — vertical size matches content so outer page scroll handles it
+            egui::ScrollArea::horizontal()
+                .id_salt("sm_graph_scroll")
+                .show(ui, |ui| {
+                    let canvas = egui::Vec2::new(total_w.max(60.0), total_h.max(60.0));
+                    let (rect, _) = ui.allocate_exact_size(canvas, egui::Sense::hover());
+                    if ui.is_rect_visible(rect) {
+                        draw_sm(
+                            ui.painter(),
+                            rect.min,
+                            &artifacts.state_infos,
+                            &nodes,
+                            &sm_highlight,
+                            &artifacts.accept_states,
+                        );
+                    }
+                });
+        });
     }
 
     fn show_parse_table(
@@ -448,15 +568,15 @@ impl ParserApp {
         symbols: &[char],
         table: &[Vec<ParseTableAction>],
         highlight: Option<(usize, char)>,
+        height: f32,
     ) {
-        let fixed_height = 300.0;
-
         ui.allocate_ui_with_layout(
-            egui::Vec2::new(ui.available_width(), fixed_height),
+            egui::Vec2::new(ui.available_width(), height),
             egui::Layout::top_down(egui::Align::LEFT),
             |ui| {
-                egui::ScrollArea::vertical()
-                    .max_height(fixed_height)
+                egui::ScrollArea::both()
+                    .id_salt("parse_table_scroll")
+                    .max_height(height)
                     .show(ui, |ui| {
                         self.render_table_grid(ui, symbols, table, highlight);
                     });
@@ -557,24 +677,21 @@ impl ParserApp {
     }
 
     fn handle_parse(&mut self) {
-        match self.selected_kind {
+        match self.parser.selected_kind {
             ParserKind::Lr0 => self.handle_parse_lr0(),
             other => {
-                self.parser_result =
+                self.parser.result =
                     UiError::NotImplemented(other.label().to_string()).to_string();
-                self.parse_trace.clear();
-                self.parse_table = None;
+                self.parser.parse_trace.clear();
+                self.parser.status = ParserStatus::Empty;
             }
         }
     }
 
     fn handle_parse_lr0(&mut self) {
         // ── フェーズ1: 独立な2チェーンを Applicative 的に合成 ──────────────────
-        // grammar → compile（依存的逐次）と input parse（独立）は互いに影響しない。
-        // map2 で合成し、両方成功した場合のみ RunRequest を生成する。
-        // 一方または両方が失敗した場合はすべてのエラーを蓄積して表示する。
-        let compiled = validated_compile(&self.reducer_string);
-        let input    = validate_input(&self.input_string);
+        let compiled = validated_compile(&self.workspace.reducer_string);
+        let input    = validate_input(&self.workspace.input_string);
 
         let request = match compiled.map2(input, |cg, symbols| RunRequest {
             grammar:       cg.grammar,
@@ -583,38 +700,350 @@ impl ParserApp {
         }) {
             Validation::Valid(req) => req,
             Validation::Invalid(errors) => {
-                self.parser_result = errors.iter()
+                self.parser.result = errors.iter()
                     .map(|e| e.to_string())
                     .collect::<Vec<_>>()
                     .join("\n");
-                self.parse_table = None;
-                self.parse_trace.clear();
+                self.parser.status = ParserStatus::Empty;
+                self.parser.parse_trace.clear();
                 return;
             }
         };
 
-        // ── フェーズ2: run（RunRequest への依存的な逐次処理） ──────────────────
-        self.parse_table = Some(build_parse_table(&request.grammar, &request.machine));
-        self.terminals   = terminals_from_grammar(&request.grammar);
+        // ── フェーズ2: compile 成功後のテーブル構築 ────────────────────────────
+        let (symbols, table) = build_parse_table(&request.grammar, &request.machine);
+        self.workspace.terminals = terminals_from_grammar(&request.grammar);
         self.apply_default_terminal_types();
 
+        // ── フェーズ3: run（RunRequest への依存的な逐次処理） ──────────────────
         match run(&request.machine, &request.input_symbols).map_err(UiError::Runtime) {
             Ok(_) => {
-                self.parser_result.clear();
+                self.parser.result.clear();
             }
             Err(e) => {
-                self.parser_result = e.to_string();
-                self.parse_trace.clear();
+                self.parser.result = e.to_string();
+                self.parser.parse_trace.clear();
+                // parse table は表示するが SM は空で返す
+                self.parser.status = ParserStatus::Ready(ParseArtifacts {
+                    symbols,
+                    table,
+                    state_infos: vec![],
+                    accept_states: vec![],
+                });
                 return;
             }
         }
 
-        self.parse_trace = build_animation_trace(&request.machine, &request.input_symbols).unwrap_or_default();
-        self.trace_cursor      = 0;
-        self.anim_playing      = false;
-        self.anim_last_advance = None;
+        let state_infos = request.machine.state_infos().to_vec();
+        let accept_states: Vec<usize> = table.iter().enumerate()
+            .filter(|(_, row)| row.iter().any(|a| matches!(a, ParseTableAction::Accept)))
+            .map(|(state, _)| state)
+            .collect();
+        self.parser.status = ParserStatus::Ready(ParseArtifacts {
+            symbols,
+            table,
+            state_infos,
+            accept_states,
+        });
+
+        self.parser.parse_trace = build_animation_trace(&request.machine, &request.input_symbols).unwrap_or_default();
+        self.parser.trace_cursor      = 0;
+        self.parser.anim_playing      = false;
+        self.parser.anim_last_advance = None;
     }
 }
+
+// ── State Machine graph layout & drawing ────────────────────────────────────
+
+const SM_NODE_R: f32 = 22.0;
+const SM_H_GAP: f32 = 105.0;
+const SM_V_GAP: f32 = 68.0;
+const SM_LABEL_OFFSET: f32 = 13.0;
+const SM_TOP_PAD: f32 = 100.0; // back-edge ctrl.y goes up to NODE_R + 32 + 36 = 90 px above origin
+
+struct SmNodePos {
+    state_id: usize,
+    x: f32,
+    y: f32,
+}
+
+fn layout_sm(state_infos: &[StateInfo]) -> (Vec<SmNodePos>, f32, f32) {
+    if state_infos.is_empty() {
+        return (vec![], 0.0, 0.0);
+    }
+    let n = state_infos.len();
+    let mut layer = vec![usize::MAX; n];
+    let mut queue = std::collections::VecDeque::new();
+    layer[0] = 0;
+    queue.push_back(0_usize);
+    while let Some(s) = queue.pop_front() {
+        for (_, next) in &state_infos[s].transitions {
+            if *next < n && layer[*next] == usize::MAX {
+                layer[*next] = layer[s] + 1;
+                queue.push_back(*next);
+            }
+        }
+    }
+    let max_reached = layer.iter().filter(|&&l| l != usize::MAX).max().copied().unwrap_or(0);
+    for l in layer.iter_mut() {
+        if *l == usize::MAX {
+            *l = max_reached + 1;
+        }
+    }
+    let num_layers = layer.iter().max().copied().unwrap_or(0) + 1;
+    let mut by_layer: Vec<Vec<usize>> = vec![vec![]; num_layers];
+    for (s, &l) in layer.iter().enumerate() {
+        by_layer[l].push(s);
+    }
+    let h_margin = SM_NODE_R * 2.0;
+    let mut nodes = vec![];
+    for (col, states) in by_layer.iter().enumerate() {
+        for (row, &s) in states.iter().enumerate() {
+            nodes.push(SmNodePos {
+                state_id: s,
+                x: col as f32 * SM_H_GAP + h_margin,
+                y: row as f32 * SM_V_GAP + SM_TOP_PAD,
+            });
+        }
+    }
+    // +70 for accept termination arrow (44px arrow + 17px dot + margin)
+    let total_w = num_layers as f32 * SM_H_GAP + h_margin * 2.0 + 70.0;
+    let max_in_layer = by_layer.iter().map(|v| v.len()).max().unwrap_or(0);
+    let total_h = max_in_layer as f32 * SM_V_GAP + SM_TOP_PAD + h_margin;
+    (nodes, total_w, total_h)
+}
+
+fn sm_bezier_point(p0: egui::Pos2, p1: egui::Pos2, p2: egui::Pos2, t: f32) -> egui::Pos2 {
+    let u = 1.0 - t;
+    egui::Pos2 {
+        x: u * u * p0.x + 2.0 * u * t * p1.x + t * t * p2.x,
+        y: u * u * p0.y + 2.0 * u * t * p1.y + t * t * p2.y,
+    }
+}
+
+fn draw_curve(painter: &egui::Painter, p0: egui::Pos2, ctrl: egui::Pos2, p2: egui::Pos2, stroke: egui::Stroke) {
+    let pts: Vec<egui::Pos2> = (0..=12)
+        .map(|i| sm_bezier_point(p0, ctrl, p2, i as f32 / 12.0))
+        .collect();
+    for w in pts.windows(2) {
+        painter.line_segment([w[0], w[1]], stroke);
+    }
+}
+
+fn draw_arrowhead(painter: &egui::Painter, tip: egui::Pos2, dir: egui::Vec2, color: egui::Color32) {
+    if dir.length_sq() < 1e-6 {
+        return;
+    }
+    let perp = egui::Vec2::new(-dir.y, dir.x);
+    let base = tip - dir * 11.0;
+    painter.add(egui::Shape::convex_polygon(
+        vec![tip, base + perp * 5.5, base - perp * 5.5],
+        color,
+        egui::Stroke::NONE,
+    ));
+}
+
+fn draw_sm(
+    painter: &egui::Painter,
+    origin: egui::Pos2,
+    state_infos: &[StateInfo],
+    nodes: &[SmNodePos],
+    highlight: &SmHighlightView,
+    accept_states: &[usize],
+) {
+    let active_edge = highlight.active_edge;
+    let source_state = highlight.source_state;
+    let result_state = highlight.result_state;
+
+    let max_id = nodes.iter().map(|n| n.state_id).max().unwrap_or(0);
+    let mut pos_of: Vec<Option<egui::Pos2>> = vec![None; max_id + 1];
+    let mut node_x: Vec<f32> = vec![0.0; max_id + 1];
+    for n in nodes {
+        let p = origin + egui::Vec2::new(n.x, n.y);
+        pos_of[n.state_id] = Some(p);
+        node_x[n.state_id] = n.x;
+    }
+
+    // ── edges ───────────────────────────────────────────────────────────────
+    for info in state_infos {
+        let Some(src_pos) = pos_of.get(info.id).and_then(|p| *p) else { continue };
+        let src_x = node_x.get(info.id).copied().unwrap_or(0.0);
+
+        // Group transitions by destination
+        let mut by_dest: std::collections::BTreeMap<usize, Vec<&Symbol>> = Default::default();
+        for (sym, dest) in &info.transitions {
+            by_dest.entry(*dest).or_default().push(sym);
+        }
+
+        for (dest, syms) in &by_dest {
+            let Some(dst_pos) = pos_of.get(*dest).and_then(|p| *p) else { continue };
+            let dst_x = node_x.get(*dest).copied().unwrap_or(0.0);
+
+            let is_active = active_edge
+                .map(|(from, terminal, to)| {
+                    from == info.id
+                        && to == *dest
+                        && syms.iter().any(|s| matches!(s, Symbol::Terminal(t) if t.0 == terminal))
+                })
+                .unwrap_or(false);
+
+            let edge_color = if is_active {
+                egui::Color32::from_rgb(255, 220, 50)
+            } else {
+                egui::Color32::from_rgb(130, 130, 150)
+            };
+            let stroke_w = if is_active { 3.5 } else { 1.5 };
+            let stroke = egui::Stroke::new(stroke_w, edge_color);
+
+            let label: String = syms
+                .iter()
+                .map(|s| match s {
+                    Symbol::Terminal(c) => format!("'{}'", c.0),
+                    Symbol::NonTerminal(c) => c.0.to_string(),
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+
+            if info.id == *dest {
+                // Self-loop
+                let loop_c = src_pos - egui::Vec2::new(0.0, SM_NODE_R + 12.0);
+                let p0 = src_pos - egui::Vec2::new(SM_NODE_R * 0.5, SM_NODE_R);
+                let p2 = src_pos + egui::Vec2::new(SM_NODE_R * 0.5, -SM_NODE_R);
+                draw_curve(painter, p0, loop_c, p2, stroke);
+                let end_dir = (p2 - loop_c).normalized();
+                draw_arrowhead(painter, p2, end_dir, edge_color);
+                painter.text(
+                    loop_c - egui::Vec2::new(0.0, 10.0),
+                    egui::Align2::CENTER_CENTER,
+                    &label,
+                    egui::FontId::monospace(10.5),
+                    edge_color,
+                );
+                continue;
+            }
+
+            if src_x < dst_x {
+                // Forward edge — straight line
+                let dir = (dst_pos - src_pos).normalized();
+                let from = src_pos + dir * SM_NODE_R;
+                let to = dst_pos - dir * SM_NODE_R;
+                painter.line_segment([from, to], stroke);
+                draw_arrowhead(painter, to, dir, edge_color);
+                let mid = egui::Pos2::new((from.x + to.x) / 2.0, (from.y + to.y) / 2.0);
+                let perp = egui::Vec2::new(-dir.y, dir.x);
+                painter.text(
+                    mid + perp * SM_LABEL_OFFSET,
+                    egui::Align2::CENTER_CENTER,
+                    &label,
+                    egui::FontId::monospace(10.5),
+                    edge_color,
+                );
+            } else {
+                // Back / same-layer edge — curved above
+                let spread = (*dest as f32 * 12.0).min(36.0);
+                let from = src_pos - egui::Vec2::new(0.0, SM_NODE_R);
+                let to   = dst_pos - egui::Vec2::new(0.0, SM_NODE_R);
+                let ctrl = egui::Pos2::new(
+                    (from.x + to.x) / 2.0,
+                    from.y.min(to.y) - 32.0 - spread,
+                );
+                draw_curve(painter, from, ctrl, to, stroke);
+                let end_dir = (to - ctrl).normalized();
+                draw_arrowhead(painter, to, end_dir, edge_color);
+                painter.text(
+                    ctrl - egui::Vec2::new(0.0, 10.0),
+                    egui::Align2::CENTER_CENTER,
+                    &label,
+                    egui::FontId::monospace(10.5),
+                    edge_color,
+                );
+            }
+        }
+    }
+
+    // ── nodes ────────────────────────────────────────────────────────────────
+    for node in nodes {
+        let Some(pos) = pos_of.get(node.state_id).and_then(|p| *p) else { continue };
+        let is_source = source_state == Some(node.state_id);
+        let is_result = result_state == Some(node.state_id);
+        let is_accept = accept_states.contains(&node.state_id);
+        let (fill, rim) = if is_source {
+            // pre-action (decision) node — orange
+            (
+                egui::Color32::from_rgb(180, 90, 20),
+                egui::Color32::from_rgb(255, 200, 50),
+            )
+        } else if is_result {
+            // post-action (destination) node — green
+            (
+                egui::Color32::from_rgb(45, 90, 70),
+                egui::Color32::from_rgb(110, 230, 170),
+            )
+        } else if is_accept {
+            // accept state — violet
+            (
+                egui::Color32::from_rgb(70, 30, 90),
+                egui::Color32::from_rgb(200, 120, 255),
+            )
+        } else {
+            (
+                egui::Color32::from_rgb(20, 55, 60),
+                egui::Color32::from_rgb(80, 160, 180),
+            )
+        };
+        painter.circle(pos, SM_NODE_R, fill, egui::Stroke::new(1.5, rim));
+        // Accept state gets a double ring to stay visible even when animated
+        if is_accept {
+            painter.circle(
+                pos,
+                SM_NODE_R + 4.0,
+                egui::Color32::TRANSPARENT,
+                egui::Stroke::new(1.5, egui::Color32::from_rgb(200, 120, 255)),
+            );
+        }
+        painter.text(
+            pos,
+            egui::Align2::CENTER_CENTER,
+            &node.state_id.to_string(),
+            egui::FontId::monospace(13.0),
+            egui::Color32::WHITE,
+        );
+    }
+
+    // ── Accept termination arrows ────────────────────────────────────────────
+    let accept_color = egui::Color32::from_rgb(200, 120, 255);
+    let accept_stroke = egui::Stroke::new(2.0, accept_color);
+    for &acc in accept_states {
+        let Some(pos) = pos_of.get(acc).and_then(|p| *p) else { continue };
+        let from = pos + egui::Vec2::new(SM_NODE_R, 0.0);
+        let to   = from + egui::Vec2::new(44.0, 0.0);
+        painter.line_segment([from, to], accept_stroke);
+        draw_arrowhead(painter, to, egui::Vec2::new(1.0, 0.0), accept_color);
+        // termination dot
+        painter.circle(
+            to + egui::Vec2::new(8.0, 0.0),
+            6.0,
+            accept_color,
+            egui::Stroke::NONE,
+        );
+        painter.circle(
+            to + egui::Vec2::new(8.0, 0.0),
+            9.0,
+            egui::Color32::TRANSPARENT,
+            accept_stroke,
+        );
+        // label
+        painter.text(
+            from + egui::Vec2::new(22.0, -11.0),
+            egui::Align2::CENTER_CENTER,
+            "$",
+            egui::FontId::monospace(11.0),
+            accept_color,
+        );
+    }
+}
+
+
 
 // ── Tree layout & drawing ────────────────────────────────────────────────────
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -243,6 +243,58 @@ mod tests {
     use crate::lr::compile;
 
     #[test]
+    fn dump_trace_for_debug() {
+        let grammar = parse_grammar_text("E -> E*B\nE -> E+B\nE -> B\nB -> 0\nB -> 1").unwrap();
+        let machine = compile(&grammar).unwrap();
+        let input = [
+            Symbol::Terminal(Terminal('1')),
+            Symbol::Terminal(Terminal('+')),
+            Symbol::Terminal(Terminal('1')),
+            Symbol::Terminal(Terminal('*')),
+            Symbol::Terminal(Terminal('1')),
+            Symbol::Terminal(Terminal('$')),
+        ];
+
+        let trace = build_trace(&machine, &input).unwrap();
+
+        println!("\n=== PARSE TRACE DUMP ===");
+        println!("grammar: E->E*B | E->E+B | E->B | B->0 | B->1");
+        println!("input:   1+1*1");
+        println!("steps:   {}", trace.len());
+        println!();
+
+        for (i, step) in trace.iter().enumerate() {
+            let action_str = match &step.action {
+                StepAction::Shift { terminal, to_state } =>
+                    format!("SHIFT '{}' -> state {}", terminal, to_state),
+                StepAction::Reduce { rule, pop_count } =>
+                    format!("REDUCE {} (pop {})", rule, pop_count),
+                StepAction::Accept => "ACCEPT".to_string(),
+            };
+
+            let sm_edge = match &step.action {
+                StepAction::Shift { terminal, to_state } =>
+                    format!("sm_edge: {} --'{}'-> {}", step.from_state, terminal, to_state),
+                StepAction::Reduce { rule, .. } =>
+                    format!("sm_edge: <none; reduce {}>", rule),
+                StepAction::Accept =>
+                    format!("sm_edge: <none; accept at {}>", step.from_state),
+            };
+
+            let stack: String = step.state_stack.iter()
+                .map(|s| s.to_string()).collect::<Vec<_>>().join(",");
+            let remaining: String = step.remaining_input.iter().collect();
+
+            println!("step {:>2}: [pre]  from_state={}  lookahead='{}'  action={}",
+                i + 1, step.from_state, step.lookahead, action_str);
+            println!("         [post] stack=[{}]  remaining='{}'", stack, remaining);
+            println!("         [sm]   {}", sm_edge);
+            println!();
+        }
+        println!("=== END TRACE DUMP ===");
+    }
+
+    #[test]
     fn run_returns_an_ast() {
         let grammar = parse_grammar_text("E -> E+B\nE -> B\nB -> 0\nB -> 1").unwrap();
         let machine = compile(&grammar).unwrap();


### PR DESCRIPTION
## 概要

egui GUI 層のアーキテクチャを段階的にリファクタリングしました。

- **Step A — Page enum 化**: `current_page: usize` を `Page { Parser, Generator }` enum に変更。`_ => {}` の死パスを排除し、分岐を型安全化。

- **Step C — ParseArtifacts / ParserStatus 導入**: `parse_table` + `state_infos` の個別フィールドを `ParseArtifacts { symbols, table, state_infos, accept_states }` にまとめ、`ParserStatus::Empty / Ready(artifacts)` で管理。`accept_states` の計算を UI 描画時から `handle_parse_lr0` に集約。

- **Step B — ParserApp 分割**: 巨大な `ParserApp` を 5 つのサブ構造体に分割。
  - `UiState` — ページ選択・フォント初期化フラグ
  - `AppServices` — `GeneratorEngine`
  - `WorkspaceState` — 入力文字列・文法テキスト・ターミナル情報
  - `GeneratorPageState` — コード生成結果・AST プレビュー等
  - `ParserPageState` — パーストレース・カーソル・アニメーション状態・`ParserStatus`

- **Step D — ViewModel / Presenter**: `TraceCursorView` + `SmHighlightView` DTO を導入。
  - `cursor_view()` で現在ステップをクローンして一度だけ取得
  - UI 関数 (`show_trace_panel` / `show_ast_formation_section` / `show_parse_table_panel` / `show_state_machine_panel`) が `&mut self` で `parse_trace[cursor]` を直接読む形を廃止
  - SM 描画の highlight ロジック（Shift/Reduce/Accept 判定）を `TraceCursorView::sm_highlight()` に集約

## その他含まれる修正

- SM アニメーション: Shift のみエッジハイライト、Reduce は結果ステートをハイライト
- Parser ページを 2 カラムレイアウト（左: Input + Table、右: Trace + AST + SM）に変更
- Accept ステートにバイオレットの二重リングと `$` ラベル付き終端矢印を追加
- Trace Debug 折りたたみパネルを追加
- `CLAUDE.md` を追加（プロジェクト構造・コマンドを文書化）

## テスト

- `cargo test`: 全 19 テスト pass
- `cargo run`: 動作確認済み

🤖 Generated with [Claude Code](https://claude.ai/claude-code)